### PR TITLE
Revise filter script with options to include/exclude based on page attributes

### DIFF
--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -34,7 +34,7 @@ from tqdm import tqdm
 
 def filter_pages(
     input_filename: str,
-    source_ids: list[str] | None,
+    source_ids: list[str] | None = None,
     disable_progress: bool = False,
     include_filter: dict | None = None,
     exclude_filter: dict | None = None,
@@ -144,6 +144,8 @@ class MergeKeyValuePairs(argparse.Action):
     """
 
     # adapted from https://stackoverflow.com/a/77148515/9706217
+
+    # NOTE: we may want a multidict here to support multiple values for the same key
 
     def __call__(self, parser, args, values, option_string=None):
         previous = getattr(args, self.dest, None) or dict()

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -179,12 +179,22 @@ def main():
         "output", help="filename where the filtered corpus should be saved"
     )
     parser.add_argument(
+        "--progress",
+        help="Show progress",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    filter_args = parser.add_argument_group(
+        "filters",
+        "Options for filtering pages. At least one filter is required",
+    )
+    filter_args.add_argument(
         "-i",
         "--idfile",
         help="filename with list of source ids, one per line",
         required=False,
     )
-    parser.add_argument(
+    filter_args.add_argument(
         "--include",
         nargs="*",
         action=MergeKeyValuePairs,
@@ -192,7 +202,7 @@ def main():
         help='Include pages by attribute: add key-value pairs as key=value or key="another value". '
         + "(no spaces around =, use quotes for values with spaces)",
     )
-    parser.add_argument(
+    filter_args.add_argument(
         "--exclude",
         nargs="*",
         action=MergeKeyValuePairs,
@@ -200,18 +210,16 @@ def main():
         help='Exclude pages by attribute: add key-value pairs as key=value or key="another value". '
         + "(no spaces around =, use quotes for values with spaces)",
     )
-    parser.add_argument(
-        "--progress",
-        help="Show progress",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-    )
 
     args = parser.parse_args()
     # progress bar is enabled by default; disable if requested
     disable_progress = not args.progress
 
-    # TODO: check that one of idfile, include, or exclude is specified
+    # at least one filter must be specified
+    # check that one of idfile, include, or exclude is specified
+    if not any([args.idfile, args.include, args.exclude]):
+        parser.error("At least one filter option must be specified")
+
     # TODO: use file or pathlib types?
 
     if args.idfile:

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -75,35 +75,29 @@ def filter_pages(
         # which is either source id (for full works) or
         # source id plus first page number (for articles/excerpts)
 
-        # list of flags for inclusion/exclusion, for combining filters
-        include_page = []
-
-        # if list of source ids is specified, set true or false for inclusion
+        # if list of source ids is specified and id does not match, skip
         if source_ids:
-            include_page.append(page["work_id"].split("-p")[0] in source_ids)
+            if page["work_id"].split("-p")[0] not in source_ids:
+                continue
 
         # if key-value pairs for inclusion are specified, filter
         if include_filter:
             # multiple include filters use OR logic:
-            # if any include filter applies, this page should be included
-            include_page.append(
-                any(page[key] == val for key, val in include_filter.items())
-            )
+            # if include filter does not apply, skip this page
+            if not any(page[key] == val for key, val in include_filter.items()):
+                continue
 
         # if key-value pairs for exclusion are specified, filter
         if exclude_filter:
-            # if any exclusion filter applies, this page should not be included
-            include_page.append(
-                not any(page[key] == val for key, val in exclude_filter.items())
-            )
+            # if exclude filter matches, skip this page
+            if any(page[key] == val for key, val in exclude_filter.items()):
+                continue
 
-        # make sure we have at least one True flag and all flags are True
-        if include_page and all(include_page):
-            # keep track of how many have been selected for reporting in
-            # progress bar
-            selected_pages += 1
-            progress_pages.set_postfix_str(f"selected {selected_pages:,}")
-            yield page
+        # keep track of how many have been selected for reporting in
+        # progress bar
+        selected_pages += 1
+        progress_pages.set_postfix_str(f"selected {selected_pages:,}")
+        yield page
 
 
 def save_filtered_corpus(

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -47,9 +47,9 @@ def filter_pages(
     :param input_filename: str, filename for corpus input
     :param source_ids: list of str, source ids to include in filtered pages
     :param include_filter: dict of key-value pairs for pages to include in
-        the filtered page set; equality check against page data attributes
+        the filtered page set; equality check against page data attributes (optional)
     :param exclude_filter: dict of key-value pairs for pages to exclude from
-        the filtered page set; equality check against page data attributes
+        the filtered page set; equality check against page data attributes (optional)
     :param disable_progress: boolean, disable progress bar (optional, default: False)
     :returns: generator of dict with page data
     :raises: FileNotFoundError, orjson.JSONDecodeError
@@ -78,7 +78,7 @@ def filter_pages(
 
         # if key-value pairs for inclusion are specified, filter
         if include_filter:
-            # should multiple inclusions be AND or OR? assuming OR for now
+            # multiple include filters use OR logic:
             # if any include filter applies, this page should be included
             include_page.append(
                 any(page[key] == val for key, val in include_filter.items())
@@ -116,6 +116,10 @@ def save_filtered_corpus(
     :param input_filename: str, filename for corpus input
     :param output_filename: str, filename for filtered corpus output
     :param idfile: str, filename for list of source ids (optional)
+    :param include_filter: dict of key-value pairs for pages to include in
+        the filtered page set; equality check against page data attributes (optional)
+    :param exclude_filter: dict of key-value pairs for pages to exclude from
+        the filtered page set; equality check against page data attributes (optional)
     :param disable_progress: boolean, disable progress bar (optional, default: False)
     """
 
@@ -186,7 +190,10 @@ def main():
     )
     filter_args = parser.add_argument_group(
         "filters",
-        "Options for filtering pages. At least one filter is required",
+        "Options for filtering pages. MUST include at least one. "
+        + "When multiple filters are specified, they are all combined (AND). "
+        + "If multiple include/exclude filters are specified, a page is "
+        + "included/excluded if ANY key=value pairs match.",
     )
     filter_args.add_argument(
         "-i",

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -126,7 +126,7 @@ def save_filtered_corpus(
         output_filename,
         filter_pages(
             input_filename,
-            source_ids,
+            source_ids=source_ids,
             disable_progress=disable_progress,
             include_filter=include_filter,
             exclude_filter=exclude_filter,

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -46,6 +46,10 @@ def filter_pages(
 
     :param input_filename: str, filename for corpus input
     :param source_ids: list of str, source ids to include in filtered pages
+    :param include_filter: dict of key-value pairs for pages to include in
+        the filtered page set; equality check against page data attributes
+    :param exclude_filter: dict of key-value pairs for pages to exclude from
+        the filtered page set; equality check against page data attributes
     :param disable_progress: boolean, disable progress bar (optional, default: False)
     :returns: generator of dict with page data
     :raises: FileNotFoundError, orjson.JSONDecodeError

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -40,9 +40,10 @@ def filter_pages(
     exclude_filter: dict | None = None,
 ) -> Iterator[dict]:
     """Takes a filename for a PPA full-text corpus in a format orjsonl supports
-    and a list of source ids. Returns a generator of filtered pages from the
-    full corpus corresponding to the list of ids.  Displays progress
-    with :mod:`tqdm` progress bar unless disabled.
+    and one or more options for filtering that corpus. Returns a generator of
+    filtered pages from the full corpus corresponding to the list of ids.
+    At least one filtering option must be specified.
+    Displays progress with :mod:`tqdm` progress bar unless disabled.
 
     :param input_filename: str, filename for corpus input
     :param source_ids: list of str, source ids to include in filtered pages
@@ -55,6 +56,11 @@ def filter_pages(
     :raises: FileNotFoundError, orjson.JSONDecodeError
     """
     # convert list of source ids to set for fast hashmap lookup
+    if not any([source_ids, include_filter, exclude_filter]):
+        raise ValueError(
+            "At least one filter must be specified (source_ids, include_filter, exclude_filter)"
+        )
+
     if source_ids is not None:
         source_ids = set(source_ids)
     selected_pages = 0
@@ -111,6 +117,7 @@ def save_filtered_corpus(
     """Takes a filename for input PPA full-text corpus in a format
     orjsonl supports, filename where filtered corpus should be saved,
     and a filename with a list of source ids, one id per line.
+    At least one filter must be specified.
     Calls :meth:`filter_pages`.
 
     :param input_filename: str, filename for corpus input
@@ -124,6 +131,13 @@ def save_filtered_corpus(
     """
 
     source_ids = None
+
+    # at least one filter is required
+    if not any([idfile, include_filter, exclude_filter]):
+        raise ValueError(
+            "At least one filter must be specified (idfile, include_filter, exclude_filter)"
+        )
+
     # if an id file is specifed, read and generate a list of ids to include
     if idfile:
         with open(idfile) as idfile_content:

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -55,7 +55,7 @@ def filter_pages(
     :returns: generator of dict with page data
     :raises: FileNotFoundError, orjson.JSONDecodeError
     """
-    # convert list of source ids to set for fast hashmap lookup
+    # at least one filter is required
     if not any([source_ids, include_filter, exclude_filter]):
         raise ValueError(
             "At least one filter must be specified (source_ids, include_filter, exclude_filter)"

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -54,9 +54,9 @@ def test_filter_exclude(corpus_file):
             exclude_filter={"work_id": "bar-p1", "label": "23"},
         )
     )
-    assert len(results) == 4
-    assert set([r["work_id"].split("-")[0] for r in results]) == {"bar", "baz"}
-    assert set([r["label"] for r in results]) == {"1", "2", "3", "23"}
+    assert len(results) == 1
+    assert set([r["work_id"].split("-")[0] for r in results]) == {"foo"}
+    assert set([r["label"] for r in results]) == {"i"}
 
 
 def test_filter_id_and_include(corpus_file):

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -128,7 +128,7 @@ def test_save_filtered_corpus(mock_orjsonl, mock_filter_pages, tmpdir):
                 },
             ),
         ),
-        # # no extension on output file; should add jsonl
+        # no extension on output file; should add jsonl
         (
             ["filter.py", "pages.json", "subset", "--idfile", "id.txt"],
             (
@@ -141,6 +141,32 @@ def test_save_filtered_corpus(mock_orjsonl, mock_filter_pages, tmpdir):
                 },
             ),
         ),
+        # include filter
+        (
+            ["filter.py", "pages.json", "subset", "--include", "tag=one", "page=2"],
+            (
+                ("pages.json", "subset.jsonl"),
+                {
+                    "idfile": None,
+                    "disable_progress": False,
+                    "include_filter": {"tag": "one", "page": "2"},
+                    "exclude_filter": None,
+                },
+            ),
+        ),
+        # exclude filter
+        (
+            ["filter.py", "pages.json", "subset", "--exclude", "contains_poetry=Yes"],
+            (
+                ("pages.json", "subset.jsonl"),
+                {
+                    "idfile": None,
+                    "disable_progress": False,
+                    "include_filter": None,
+                    "exclude_filter": {"contains_poetry": "Yes"},
+                },
+            ),
+        ),
     ],
 )
 @patch("corppa.utils.filter.save_filtered_corpus")
@@ -148,8 +174,9 @@ def test_main(mock_save_filtered_corpus, cli_args, call_params, tmp_path):
     # change to temp directory, make sure id file exists and is non-zero
     os.chdir(tmp_path)
     # create an idfile at expected path; arg comes immediately after --idfile
-    idfile = tmp_path / cli_args[cli_args.index("--idfile") + 1]
-    idfile.write_text("id1\nid2")
+    if "--idfile" in cli_args:
+        idfile = tmp_path / cli_args[cli_args.index("--idfile") + 1]
+        idfile.write_text("id1\nid2")
 
     # patch in test args for argparse to parse
     with patch("sys.argv", cli_args):

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -226,6 +226,13 @@ def test_main(mock_save_filtered_corpus, cli_args, call_params, tmp_path):
         mock_save_filtered_corpus.assert_called_with(*args, **kwargs)
 
 
+def test_main_argparse_error():
+    # call with required parameters but no filters
+    with patch("sys.argv", ["filter.py", "pages.json", "subset"]):
+        with pytest.raises(SystemExit):
+            main()
+
+
 @patch("corppa.utils.filter.save_filtered_corpus")
 def test_main_idfile_nonexistent(mock_save_filtered_corpus, capsys):
     with patch(

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -33,6 +33,47 @@ def test_filter_pages(corpus_file):
     assert set([r["work_id"].split("-")[0] for r in results]) == set(source_ids)
 
 
+def test_filter_include(corpus_file):
+    results = list(
+        filter_pages(
+            str(corpus_file),
+            disable_progress=True,
+            include_filter={"work_id": "bar-p1", "label": "23"},
+        )
+    )
+    assert len(results) == 4
+    assert set([r["work_id"].split("-")[0] for r in results]) == {"bar", "baz"}
+    assert set([r["label"] for r in results]) == {"1", "2", "3", "23"}
+
+
+def test_filter_exclude(corpus_file):
+    results = list(
+        filter_pages(
+            str(corpus_file),
+            disable_progress=True,
+            include_filter={"work_id": "bar-p1", "label": "23"},
+        )
+    )
+    assert len(results) == 4
+    assert set([r["work_id"].split("-")[0] for r in results]) == {"bar", "baz"}
+    assert set([r["label"] for r in results]) == {"1", "2", "3", "23"}
+
+
+def test_filter_id_and_include(corpus_file):
+    # source id and include filter used in combination
+    results = list(
+        filter_pages(
+            str(corpus_file),
+            source_ids=["bar"],
+            disable_progress=True,
+            include_filter={"label": "2", "work_id": "baz"},
+        )
+    )
+    assert len(results) == 1
+    assert results[0]["work_id"] == "bar-p1"
+    assert results[0]["label"] == "2"
+
+
 @patch("corppa.utils.filter.tqdm")
 @patch("corppa.utils.filter.orjsonl")
 def test_filter_pages_progressbar(mock_orjsonl, mock_tqdm, corpus_file):

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -51,7 +51,7 @@ def test_filter_exclude(corpus_file):
         filter_pages(
             str(corpus_file),
             disable_progress=True,
-            include_filter={"work_id": "bar-p1", "label": "23"},
+            exclude_filter={"work_id": "bar-p1", "label": "23"},
         )
     )
     assert len(results) == 4

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -122,7 +122,7 @@ def test_save_filtered_corpus(mock_orjsonl, mock_filter_pages, tmpdir):
     # filter should be called with input file and list of ids from text file
     mock_filter_pages.assert_called_with(
         input_filename,
-        ids,
+        source_ids=ids,
         disable_progress=False,
         include_filter=None,
         exclude_filter=None,


### PR DESCRIPTION
Update filter script to make filter by id optional and add flags to include / exclude pages based on arbitrary attributes. 

I successfully used this to filter the poetry test set into poetry and non-poetry chunks based on the `contains_poetry` flag that was set by Laure's `create_pageset` script.

## changes:
- [x] update docstring for `filter_pages` to document new params
- [x] throw error if no filter args are specified
- [x] check filter logic: can we continue on failure

