### PR TITLE
Ruff fix imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,5 +4,5 @@ repos:
     rev: v0.3.4
     hooks:
       - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
+        args: [ --select, I, --fix, --exit-non-zero-on-fix ]
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,7 @@ corppa-ocr = "corppa.ocr.gvision_ocr:main"
 
 [tool.hatch.version]
 path = "src/corppa/__init__.py"
+
+[tool.ruff]
+# configure src path so ruff import fixes can identify local imports
+src = ["src"]

--- a/scripts/evaluate_ocr.py
+++ b/scripts/evaluate_ocr.py
@@ -1,13 +1,13 @@
+import csv
 import os
 import sys
-import spacy
-import csv
-import orjsonl
 
-from xopen import xopen
-from tqdm import tqdm
+import orjsonl
+import spacy
 from lingua import LanguageDetectorBuilder
 from ocr_helper import clean_chars
+from tqdm import tqdm
+from xopen import xopen
 
 
 class OCREvaluator:

--- a/scripts/get_character_stats.py
+++ b/scripts/get_character_stats.py
@@ -4,17 +4,16 @@ Script for collectin character-level statistics
 env: ppa-ocr
 """
 
-import sys
-import os.path
 import csv
+import os.path
+import sys
 import unicodedata
+from collections import Counter
 
 import orjsonl
-from collections import Counter
-from xopen import xopen
-from tqdm import tqdm
 from ocr_helper import clean_chars
-
+from tqdm import tqdm
+from xopen import xopen
 
 __cc_names = {
     "\n": "Cc: LINE FEED",

--- a/scripts/ocr_helper.py
+++ b/scripts/ocr_helper.py
@@ -4,7 +4,6 @@ Library of OCR-related auxiliary methods for stand-alone scripts
 
 import ftfy
 
-
 _char_conversion_map = {"ſ": "s"}
 _char_translation_table = str.maketrans(_char_conversion_map)
 

--- a/src/corppa/ocr/gvision_ocr.py
+++ b/src/corppa/ocr/gvision_ocr.py
@@ -10,8 +10,9 @@ import os
 import pathlib
 import sys
 
-from corppa.utils.path_utils import get_ppa_source, get_vol_dir
 from tqdm import tqdm
+
+from corppa.utils.path_utils import get_ppa_source, get_vol_dir
 
 # Attempt to import Google Cloud Vision Python Client
 try:

--- a/src/corppa/ocr/gvision_ocr.py
+++ b/src/corppa/ocr/gvision_ocr.py
@@ -4,14 +4,14 @@
 This script OCRs images using the Google Vision API.
 """
 
-import os
-import sys
-import io
-import pathlib
 import argparse
+import io
+import os
+import pathlib
+import sys
 
+from corppa.utils.path_utils import get_ppa_source, get_vol_dir
 from tqdm import tqdm
-from corppa.utils.path_utils import get_vol_dir, get_ppa_source
 
 # Attempt to import Google Cloud Vision Python Client
 try:

--- a/src/corppa/poetry_detection/annotation/add_metadata.py
+++ b/src/corppa/poetry_detection/annotation/add_metadata.py
@@ -17,8 +17,8 @@ import pathlib
 import sys
 from typing import Iterator
 
-from tqdm import tqdm
 import orjsonl
+from tqdm import tqdm
 
 
 def combine_data(

--- a/src/corppa/poetry_detection/annotation/create_pageset.py
+++ b/src/corppa/poetry_detection/annotation/create_pageset.py
@@ -6,15 +6,15 @@ env: ppa-data
 """
 
 import csv
-import os.path
 import json
+import os.path
 import re
 import sys
 
 import orjsonl
-from xopen import xopen
-from tqdm import tqdm
 from helper import encode_htid, get_stub_dir
+from tqdm import tqdm
+from xopen import xopen
 
 
 def extract_page_numbers(page_url_list):

--- a/src/corppa/poetry_detection/annotation/recipe.py
+++ b/src/corppa/poetry_detection/annotation/recipe.py
@@ -13,11 +13,11 @@ prodigy annotate_page_text poetry_spans poetry_pages.jsonl --label POETRY,PROSOD
 prodigy annotate_text_and_image poetry_text_image poetry_pages.jsonl --label POETRY -F ../corppa/poetry_detection/annotation/recipe.py --image-prefix http://localhost:8000/
 """
 
-from prodigy.core import Arg, recipe
-from prodigy.components.loaders import JSONL
-import spacy
-
 from pathlib import Path
+
+import spacy
+from prodigy.components.loaders import JSONL
+from prodigy.core import Arg, recipe
 
 #: reference to current directory, for use as Prodigy CSS directory
 CURRENT_DIR = Path(__file__).parent.absolute()

--- a/src/corppa/utils/filter.py
+++ b/src/corppa/utils/filter.py
@@ -24,8 +24,8 @@ with or without compression; e.g. `.jsonl`, `.jsonl.gz`, `.jsonl.bz2`, etc.
 
 import argparse
 import os.path
-from typing import Iterator
 import sys
+from typing import Iterator
 
 import orjsonl
 from orjson import JSONDecodeError

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+
 from corppa.utils.filter import filter_pages, main, save_filtered_corpus
 
 # minimal/mock page data fixture for testing

--- a/test/test_utils/test_filter.py
+++ b/test/test_utils/test_filter.py
@@ -3,8 +3,7 @@ import os
 from unittest.mock import patch
 
 import pytest
-
-from corppa.utils.filter import filter_pages, save_filtered_corpus, main
+from corppa.utils.filter import filter_pages, main, save_filtered_corpus
 
 # minimal/mock page data fixture for testing
 fixture_page_data = [

--- a/test/test_utils/test_path_utils.py
+++ b/test/test_utils/test_path_utils.py
@@ -1,10 +1,10 @@
 import pathlib
-import pytest
-
 from unittest.mock import patch
+
+import pytest
 from corppa.utils.path_utils import (
-    encode_htid,
     decode_htid,
+    encode_htid,
     get_ppa_source,
     get_stub_dir,
     get_vol_dir,

--- a/test/test_utils/test_path_utils.py
+++ b/test/test_utils/test_path_utils.py
@@ -2,6 +2,7 @@ import pathlib
 from unittest.mock import patch
 
 import pytest
+
 from corppa.utils.path_utils import (
     decode_htid,
     encode_htid,


### PR DESCRIPTION
- Configure ruff pre-commit hook to fix imports (note: this change requires running `pre-commit install`)
- add ruff tool configuration section to pyproject.toml so ruff can identify local project imports
- apply ruff import fixes to existing code