### PR TITLE
Feature/eval spans

### DIFF
--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -1,0 +1,20 @@
+# Evaluation
+This directory contains code to evaluate methods for detecting and identifying
+poetry excerpts.
+
+
+## Terminoloy
+In this setting, we assume we have two sets of annotations: a *reference* set and
+a *system* set. In the typical scenario, we are evaluating some system's results
+against some baseline annotations serving as a sort of "ground truth". This lets
+us ask how well the system identifies poetry excerpts compared to this baseline
+(e.g., how many does it miss? how many unexpected excerpts does it flag?). That
+said, we can use the same code to compare the agreement of two sets of annotations
+(produced by humans or computers).
+
+In our particular setting, our evaluation dataset is a small subset of PPA pages
+from our adjudicated dataset. These hand-identified spans of poetry were then
+manually identified to particular poems.
+
+## Page-level Span Evaluation
+TODO

--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -1,9 +1,8 @@
 # Evaluation
-This directory contains code to evaluate methods for detecting and identifying
+This directory contains code to evaluate methods for detecting (and identifying)
 poetry excerpts.
 
-
-## Terminoloy
+## Terminology
 In this setting, we assume we have two sets of annotations: a *reference* set and
 a *system* set. In the typical scenario, we are evaluating some system's results
 against some baseline annotations serving as a sort of "ground truth". This lets
@@ -12,9 +11,72 @@ us ask how well the system identifies poetry excerpts compared to this baseline
 said, we can use the same code to compare the agreement of two sets of annotations
 (produced by humans or computers).
 
-In our particular setting, our evaluation dataset is a small subset of PPA pages
-from our adjudicated dataset. These hand-identified spans of poetry were then
-manually identified to particular poems.
+## Evaluation Dataset
+In order to evaluate computational methods for detecting poetry excerpts, we
+built a small evaluation dataset to use as our reference set. For a small subset of
+adjudicated spans from our annotation task, we manually identified the poems and
+constructed a `.JSONL` file containing these annotations to use for evaluation.
 
-## Page-level Span Evaluation
-TODO
+## Page-level Span Evaluation Method
+We compare the poetry span annotations produced at the page level calculating page-level
+precision and recall scores. Our approach builds off existing methods for evaluation span
+annotations, but makes design choices suitable to our task.
+
+### Assumptions
+**Spans.** In this setting a span to have the following three components:
+- start: Start index of the span
+- end: End index of the span
+- label: The ID of the referenced poem
+
+Note that a span's interval is Pythonic [closed, open) interval.
+
+**Reference Spans.** We assume that a reference's spans do not overlap. Either the entire span
+is an excerpt from a poem or it is not. Note that our method can generally accomodate overlapping
+spans if they have different labels (i.e., one poem reuses a line from yet another poem), but only
+if poem labels are taken into account.
+
+**System Spans.** Unlike reference spans, system spans are permitted to overlap. This can easily
+happen in the case of passim where overlapping passages can be identified for different lines of
+the same reference poem.
+
+## Span Overlap Factor
+Taking inspiration from Stanislav Olenchenko's [blog post](https://blog.p1k.org/yet-another-way-of-ner-systems-evaluation/),
+we define the overlap factor between two spans $a$ and $b$ *with the same poem label* to be equal to
+the proportion of the overlap of their intervals with respect to the larger span.
+
+$$
+\text{overlap-factor}(a, b) = \frac{\min(a_{end}, b_{end}) - \max(a_{start}, b_{start})}{\max(a_{end}-a_{start}, b_{end}-b_{start})}
+$$
+
+### Step 1. Map reference spans to viable system spans
+In this first step, we take inspiration from ACE NER evaluation metrics (see Hal Daume's [blog post comment](https://nlpers.blogspot.com/2006/08/doing-named-entity-recognition-dont.html?showComment=1156981200000#c115698122985619877)). We effectively build a bipartite graph linking
+each reference span to the "best" matching system span. Currently, we determine the best matching
+system span for each reference span independently. For each reference span, we select the
+system span with the greatest overlap factor. This may result multiple reference spans linking to
+the same system span.
+
+Note that this selection process will greatly penalize systems that separate a poem excerpt into
+multiple spans.
+
+### Step 2. Determine Reference-"System" Span Pairs
+To calculate precision and recall scores, we must have one-to-one style mappings between reference
+and system spans. This is straightforward from our reference-system span mapping if each system
+span is linked with at most one reference span. However, if $k$ reference spans map to a
+single system span, we'll need to split the system span into $k$ distinct subspans.
+
+#### Splitting System Spans
+For reference spans $r_0 \dots r_k$ mapping to a single system span $s$, we split $s$ into the following
+$k$ sub-spans using of the starting index of all but the first reference span:
+
+$$
+\left(s_{start}, r_{1_{start}} \right),
+\left(r_{1_{start}}, r_{2_{start}} \right),
+\cdots,
+\left(r_{k_{start}}, s_{end} \right)
+$$
+
+
+### Step 3. Calculating Precision and Recall
+
+
+## Script Details

--- a/src/corppa/poetry_detection/evaluation/evaluate_poetry_spans.py
+++ b/src/corppa/poetry_detection/evaluation/evaluate_poetry_spans.py
@@ -2,8 +2,6 @@
 Evaluate the poetry spans detected by a system against a provided reference set.
 """
 
-from functools import cached_property
-
 
 class Span:
     """
@@ -20,7 +18,10 @@ class Span:
     def __len__(self) -> int:
         return self.end - self.start
 
-    def __eq__(self, other: "Span") -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Span):
+            # For __eq__ to "work" with arbitrary objects
+            return NotImplemented
         return (
             self.start == other.start
             and self.end == other.end
@@ -89,7 +90,8 @@ class PageReferenceSpans:
         self.page_id = page_json["page_id"]
         self.spans = self._get_spans(page_json)
 
-    def _get_spans(self, page_json):
+    @staticmethod
+    def _get_spans(page_json):
         """
         Get span list from page-level json
         """
@@ -107,17 +109,18 @@ class PageSystemSpans:
     """
     Page-level system spans object.
 
-    Note: Unlike a page's reference spans, the spans produced by a system might overlap.
-    might overlap. While these overlapping spans are worth penalizing when span labels are
-    taken in to account, this seems less true when labels are ignored.
+    Note: Unlike a page's reference spans, the spans produced by a system might
+    overlap. While these overlapping spans are worth penalizing when span labels
+    are taken in to account, this seems less true when labels are ignored.
     """
 
     def __init__(self, page_json):
         self.page_id = page_json["page_id"]
         self.labeled_spans = self._get_labeled_spans(page_json)
-        self.unlabeled_spans = self._get_unlabeled_spans()
+        self.unlabeled_spans = self._get_unlabeled_spans(self.labeled_spans)
 
-    def _get_labeled_spans(self, page_json):
+    @staticmethod
+    def _get_labeled_spans(page_json):
         """
         Get (labeled) spans from page-level json
         """
@@ -129,13 +132,14 @@ class PageSystemSpans:
         spans.sort(key=lambda x: (x.start, x.end))
         return spans
 
-    def _get_unlabeled_spans(self):
+    @staticmethod
+    def _get_unlabeled_spans(labeled_spans):
         """
         Get "label-free" spans derived from object's labeled spans. All overlapping
         (but not adjacent) spans are merged into a single span.
         """
         spans = []
-        for i, labeled_span in enumerate(self.labeled_spans):
+        for i, labeled_span in enumerate(labeled_spans):
             unlabeled_span = Span(labeled_span.start, labeled_span.end, "")
             if not i:
                 # Edge case: Add the unlabeled version of the first span
@@ -156,12 +160,19 @@ class PageEvaluation:
     Page-level span evaluation.
     """
 
+    ignore_label: bool  # Flag for ignoring span labels in evaluation
+    ref_spans: list[Span]  # Reference spans
+    sys_spans: list[Span]  # System spans
+    ref_to_sys: list[int | None]  # Mapping from reference to system spans
+    sys_to_refs: list[list[int]]  # Mapping from system to references spans
+    span_pairs: list[tuple[Span, Span]]  # List of reference-system span pairs.
+
     def __init__(
         self,
         page_ref_spans: PageReferenceSpans,
         page_sys_spans: PageSystemSpans,
         ignore_label: bool = False,
-    ):
+    ) -> None:
         if page_ref_spans.page_id != page_sys_spans.page_id:
             raise ValueError(
                 "Reference and system spans must correspond to the same page"
@@ -174,43 +185,54 @@ class PageEvaluation:
         else:
             self.sys_spans = page_sys_spans.labeled_spans
         # Determine mappings between reference and system spans
-        self.ref_to_sys, self.sys_to_refs = self._get_span_mappings()
+        self.ref_to_sys, self.sys_to_refs = self._get_span_mappings(
+            self.ref_spans, self.sys_spans, self.ignore_label
+        )
         # Determine the reference-system span pairs
-        self.span_pairs = self._get_span_pairs()
+        self.span_pairs = self._get_span_pairs(
+            self.ref_spans, self.sys_spans, self.sys_to_refs
+        )
 
-    def _get_span_mappings(self):
+    @staticmethod
+    def _get_span_mappings(
+        ref_spans: list[Span],
+        sys_spans: list[Span],
+        ignore_label: bool,
+    ) -> tuple[list[int | None], list[list[int]]]:
         """
         Determines the mappings between the reference and system spans. Each
         reference span is mapped to at most one system span. Namely, the system
         span with the highest degree of overlap. Conversely, each system span
         is mapped to any number of overlapping (but disjoint) reference spans.
         """
-        ref_to_sys = [None for _ in self.ref_spans]
-        sys_to_refs = [[] for _ in self.sys_spans]
+        ref_to_sys: list[int | None] = [None for _ in ref_spans]
+        sys_to_refs: list[list[int]] = [[] for _ in sys_spans]
 
         # Assign each reference span to at most one system span
-        for i, ref_span in enumerate(self.ref_spans):
+        for i, ref_span in enumerate(ref_spans):
             current_match_idx = None
-            current_match_overlap = 0
+            current_match_overlap: float = 0
             # Note: given these have an ordering this could be optimized
-            for j, sys_span in enumerate(self.sys_spans):
-                overlap = ref_span.overlap_factor(
-                    sys_span, ignore_label=self.ignore_label
-                )
+            for j, sys_span in enumerate(sys_spans):
+                overlap = ref_span.overlap_factor(sys_span, ignore_label=ignore_label)
                 if overlap > current_match_overlap:
                     current_match_idx = j
                     current_match_overlap = overlap
             # Update mappings if a match is found
             if current_match_idx is not None:
                 ref_to_sys[i] = current_match_idx
-                sys_to_refs[j].append(i)
+                sys_to_refs[current_match_idx].append(i)
         return ref_to_sys, sys_to_refs
 
-    def _get_span_pairs(self):
+    @staticmethod
+    def _get_span_pairs(
+        ref_spans: list[Span],
+        sys_spans: list[Span],
+        sys_to_refs: list[list[int]],
+    ) -> list[tuple[Span, Span]]:
         """
-        Determines the reference-system span pairs for evaluation using the
-        existing mappings between reference and system pairs (`ref_to_sys`,
-        `sys_to_refs`). A span pair corresponds is a tuple of
+        Determines the reference-system span pairs used in evaluation.
+        A span pair corresponds to a tuple of
             1. A reference span r mapped to system span s
             2. The system span s if s solely maps to r. Otherwise, a subspan of s.
 
@@ -219,37 +241,65 @@ class PageEvaluation:
             (s start, r_1 start), (r_1 start, r_2 start), ..., (r_k start, s end)
         """
         span_pairs = []
-        for sys_id, ref_ids in self.sys_to_refs.items():
-            sys_span = self.sys_spans[sys_id]
+        for sys_id, ref_ids in enumerate(sys_to_refs):
+            sys_span = sys_spans[sys_id]
             if len(ref_ids) == 1:
-                ref_span = self.ref_spans[ref_ids[0]]
-                span_pairs.append(ref_span, sys_span)
+                ref_span = ref_spans[ref_ids[0]]
+                span_pairs.append((ref_span, sys_span))
             else:
                 # Effectively, split system span into k pieces (one for each reference span)
                 for i, ref_id in enumerate(ref_ids):
-                    ref_span = self.ref_spans[ref_id]
+                    ref_span = ref_spans[ref_id]
                     start = ref_span.start if i else sys_span.start
-                    end = ref_span.end if i + 1 < len(ref_ids) else sys_span.end
+                    if i == len(ref_ids) - 1:
+                        end = sys_span.end
+                    else:
+                        next_ref_span = ref_spans[ref_ids[i + 1]]
+                        end = next_ref_span.start
                     sub_sys_span = Span(start, end, sys_span.label)
-                    span_pairs.append(ref_span, sub_sys_span)
+                    span_pairs.append((ref_span, sub_sys_span))
         return span_pairs
 
-    @cached_property
-    def relevance_score(self, partial_match_weight=1) -> float:
+    @staticmethod
+    def _relevance_score(
+        span_pairs: list[tuple[Span, Span]],
+        ignore_label: bool,
+        partial_match_weight: float,
+    ) -> float:
         """
-        Computes the relevance score used for calculating precision and recall.
-        Optionally can specify a downweight for partial matches.
+        Computes the relevance score for a set of reference-system span pairs.
+        This score is used to calculate precision and recall. It corresponds to
+        the effective number of relevant spans retrieved. Partial matches are
+        awarded a fractional score corresponding to the span pairs overlap
+        factor (`overlap_factor`). Optionally, partial matches can be further
+        downweighted via `partial_match_weight`.
         """
-        score = 0
-        for ref_span, sys_span in self.span_pairs:
-            if ref_span.is_exact_match(sys_span, ignore_label=self.ignore_label):
+        score: float = 0
+        for ref_span, sys_span in span_pairs:
+            if ref_span.is_exact_match(sys_span, ignore_label=ignore_label):
                 score += 1
             else:
-                score += partial_match_weight * ref_span.overlap_factor(sys_span)
+                overlap = ref_span.overlap_factor(sys_span, ignore_label=ignore_label)
+                score += partial_match_weight * overlap
         return score
 
-    @cached_property
-    def precision(self) -> float:
+    @staticmethod
+    def _retrieved_count(sys_to_refs: list[list[int]]) -> int:
+        """
+        Returns the number of (possibly split) spans retrieved by the system based
+        on the input system to reference span mapping.
+        """
+        n_retrieved = 0
+        for ref_ids in sys_to_refs:
+            if ref_ids:
+                print(ref_ids)
+                n_retrieved += len(ref_ids)
+            else:
+                # Include spurious/incorrect spans
+                n_retrieved += 1
+        return n_retrieved
+
+    def precision(self, partial_match_weight: float = 1) -> float:
         """
         Calculate page-level precision. Edge case: If there are no system spans,
         return 1 if there are also no reference spans and 0 otherwise.
@@ -258,18 +308,13 @@ class PageEvaluation:
             # Edge case to avoid divide by zero error
             return 1 if not self.ref_spans else 0
 
-        # Determine number of retrieved (possibly split) system spans.
-        n_retrieved = 0
-        for ref_ids in self.sys_to_refs:
-            if ref_ids:
-                n_retrieved += len(ref_ids)
-            else:
-                # Include spurious/incorrect spans
-                n_retrieved += 1
-        return self.relevance_score / n_retrieved
+        n_retrieved = self._retrieved_count(self.sys_to_refs)
+        relevance_score = self._relevance_score(
+            self.span_pairs, self.ignore_label, partial_match_weight
+        )
+        return relevance_score / n_retrieved
 
-    @cached_property
-    def recall(self) -> float:
+    def recall(self, partial_match_weight: float = 1) -> float:
         """
         Calculate page-level recall. Edge case: If there are no reference spans,
         return 1 if there are also no system spans and 0 otherwise.
@@ -279,7 +324,10 @@ class PageEvaluation:
             return 1 if not self.sys_spans else 0
 
         n_relevant = len(self.ref_spans)
-        return self.relevance_score / n_relevant
+        relevance_score = self._relevance_score(
+            self.span_pairs, self.ignore_label, partial_match_weight
+        )
+        return relevance_score / n_relevant
 
 
 def get_page_span_evaluation():

--- a/src/corppa/poetry_detection/evaluation/evaluate_poetry_spans.py
+++ b/src/corppa/poetry_detection/evaluation/evaluate_poetry_spans.py
@@ -1,0 +1,294 @@
+"""
+Evaluate the poetry spans detected by a system against a provided reference set.
+"""
+
+from functools import cached_property
+
+
+class Span:
+    """
+    Span object representing a Pythonic "closed open" interval.
+    """
+
+    def __init__(self, start: int, end: int, label: str):
+        if end <= start:
+            raise ValueError("Start index must be less than end index")
+        self.start = start
+        self.end = end
+        self.label = label
+
+    def __len__(self) -> int:
+        return self.end - self.start
+
+    def __eq__(self, other: "Span") -> bool:
+        return (
+            self.start == other.start
+            and self.end == other.end
+            and self.label == other.label
+        )
+
+    def __repr__(self) -> str:
+        return f"Span({self.start}, {self.end}, {self.label})"
+
+    def has_overlap(self, other: "Span", ignore_label: bool = False) -> bool:
+        """
+        Returns whether this span overlaps with the other span.
+        Optionally, span labels can be ignored.
+        """
+        if ignore_label or self.label == other.label:
+            return self.start < other.end and other.start < self.end
+        return False
+
+    def is_exact_match(self, other: "Span", ignore_label: bool = False) -> bool:
+        """
+        Checks if the other span is an exact match. Optionally, ignores
+        span labels.
+        """
+        if self.start == other.start and self.end == other.end:
+            return ignore_label or self.label == other.label
+        else:
+            return False
+
+    def overlap_length(self, other: "Span", ignore_label: bool = False) -> int:
+        """
+        Returns the length of overlap between this span and the other span.
+        Optionally, span labels can be ignored for this calculation.
+        """
+        if not self.has_overlap(other, ignore_label=ignore_label):
+            return 0
+        else:
+            return min(self.end, other.end) - max(self.start, other.start)
+
+    def overlap_factor(self, other: "Span", ignore_label: bool = False) -> float:
+        """
+        Returns the overlap factor with the other span. Optionally, span
+        labels can be ignored for this calculation.
+
+        The overlap factor is defined as follows:
+
+            * If no overlap (overlap = 0), then overlap_factor = 0.
+
+            * Otherwise, overlap_factor = overlap_length / longer_span_length
+
+        So, the overlap factor has a range between 0 and 1 with higher values
+        corresponding to a higher degree of overlap.
+        """
+        if not self.has_overlap(other, ignore_label=ignore_label):
+            return 0
+        else:
+            overlap = self.overlap_length(other, ignore_label=ignore_label)
+            return overlap / max(len(self), len(other))
+
+
+class PageReferenceSpans:
+    """
+    Page-level reference spans object
+    """
+
+    def __init__(self, page_json):
+        self.page_id = page_json["page_id"]
+        self.spans = self._get_spans(page_json)
+
+    def _get_spans(self, page_json):
+        """
+        Get span list from page-level json
+        """
+        spans = []
+        if page_json["n_excerpts"] > 0:
+            for excerpt in page_json["excerpts"]:
+                spans.append(Span(excerpt["start"], excerpt["end"], excerpt["poem_id"]))
+
+        # Sort spans by primarily by start index and secondarily by end index
+        spans.sort(key=lambda x: (x.start, x.end))
+        return spans
+
+
+class PageSystemSpans:
+    """
+    Page-level system spans object.
+
+    Note: Unlike a page's reference spans, the spans produced by a system might overlap.
+    might overlap. While these overlapping spans are worth penalizing when span labels are
+    taken in to account, this seems less true when labels are ignored.
+    """
+
+    def __init__(self, page_json):
+        self.page_id = page_json["page_id"]
+        self.labeled_spans = self._get_labeled_spans(page_json)
+        self.unlabeled_spans = self._get_unlabeled_spans()
+
+    def _get_labeled_spans(self, page_json):
+        """
+        Get (labeled) spans from page-level json
+        """
+        spans = []
+        if page_json["n_spans"] > 0:
+            for span in page_json["poem_spans"]:
+                spans.append(Span(span["page_start"], span["page_end"], span["ref_id"]))
+        # Sort spans by primarily by start index and secondarily by end index
+        spans.sort(key=lambda x: (x.start, x.end))
+        return spans
+
+    def _get_unlabeled_spans(self):
+        """
+        Get "label-free" spans derived from object's labeled spans. All overlapping
+        (but not adjacent) spans are merged into a single span.
+        """
+        spans = []
+        for i, labeled_span in enumerate(self.labeled_spans):
+            unlabeled_span = Span(labeled_span.start, labeled_span.end, "")
+            if not i:
+                # Edge case: Add the unlabeled version of the first span
+                spans.append(unlabeled_span)
+            else:
+                # If there is overlap with the previous span, merge.
+                # Note: This relies on the ordering of labeled_spans
+                prev_span = spans[-1]
+                if prev_span.has_overlap(unlabeled_span):
+                    prev_span.end = max(prev_span.end, unlabeled_span.end)
+                else:
+                    spans.append(unlabeled_span)
+        return spans
+
+
+class PageEvaluation:
+    """
+    Page-level span evaluation.
+    """
+
+    def __init__(
+        self,
+        page_ref_spans: PageReferenceSpans,
+        page_sys_spans: PageSystemSpans,
+        ignore_label: bool = False,
+    ):
+        if page_ref_spans.page_id != page_sys_spans.page_id:
+            raise ValueError(
+                "Reference and system spans must correspond to the same page"
+            )
+        # Save working input
+        self.ignore_label = ignore_label
+        self.ref_spans = page_ref_spans.spans
+        if self.ignore_label:
+            self.sys_spans = page_sys_spans.unlabeled_spans
+        else:
+            self.sys_spans = page_sys_spans.labeled_spans
+        # Determine mappings between reference and system spans
+        self.ref_to_sys, self.sys_to_refs = self._get_span_mappings()
+        # Determine the reference-system span pairs
+        self.span_pairs = self._get_span_pairs()
+
+    def _get_span_mappings(self):
+        """
+        Determines the mappings between the reference and system spans. Each
+        reference span is mapped to at most one system span. Namely, the system
+        span with the highest degree of overlap. Conversely, each system span
+        is mapped to any number of overlapping (but disjoint) reference spans.
+        """
+        ref_to_sys = [None for _ in self.ref_spans]
+        sys_to_refs = [[] for _ in self.sys_spans]
+
+        # Assign each reference span to at most one system span
+        for i, ref_span in enumerate(self.ref_spans):
+            current_match_idx = None
+            current_match_overlap = 0
+            # Note: given these have an ordering this could be optimized
+            for j, sys_span in enumerate(self.sys_spans):
+                overlap = ref_span.overlap_factor(
+                    sys_span, ignore_label=self.ignore_label
+                )
+                if overlap > current_match_overlap:
+                    current_match_idx = j
+                    current_match_overlap = overlap
+            # Update mappings if a match is found
+            if current_match_idx is not None:
+                ref_to_sys[i] = current_match_idx
+                sys_to_refs[j].append(i)
+        return ref_to_sys, sys_to_refs
+
+    def _get_span_pairs(self):
+        """
+        Determines the reference-system span pairs for evaluation using the
+        existing mappings between reference and system pairs (`ref_to_sys`,
+        `sys_to_refs`). A span pair corresponds is a tuple of
+            1. A reference span r mapped to system span s
+            2. The system span s if s solely maps to r. Otherwise, a subspan of s.
+
+        When a system span s maps to k > 1 reference spans r_i. It's split into
+        subspans with the following ranges:
+            (s start, r_1 start), (r_1 start, r_2 start), ..., (r_k start, s end)
+        """
+        span_pairs = []
+        for sys_id, ref_ids in self.sys_to_refs.items():
+            sys_span = self.sys_spans[sys_id]
+            if len(ref_ids) == 1:
+                ref_span = self.ref_spans[ref_ids[0]]
+                span_pairs.append(ref_span, sys_span)
+            else:
+                # Effectively, split system span into k pieces (one for each reference span)
+                for i, ref_id in enumerate(ref_ids):
+                    ref_span = self.ref_spans[ref_id]
+                    start = ref_span.start if i else sys_span.start
+                    end = ref_span.end if i + 1 < len(ref_ids) else sys_span.end
+                    sub_sys_span = Span(start, end, sys_span.label)
+                    span_pairs.append(ref_span, sub_sys_span)
+        return span_pairs
+
+    @cached_property
+    def relevance_score(self, partial_match_weight=1) -> float:
+        """
+        Computes the relevance score used for calculating precision and recall.
+        Optionally can specify a downweight for partial matches.
+        """
+        score = 0
+        for ref_span, sys_span in self.span_pairs:
+            if ref_span.is_exact_match(sys_span, ignore_label=self.ignore_label):
+                score += 1
+            else:
+                score += partial_match_weight * ref_span.overlap_factor(sys_span)
+        return score
+
+    @cached_property
+    def precision(self) -> float:
+        """
+        Calculate page-level precision. Edge case: If there are no system spans,
+        return 1 if there are also no reference spans and 0 otherwise.
+        """
+        if not self.sys_spans:
+            # Edge case to avoid divide by zero error
+            return 1 if not self.ref_spans else 0
+
+        # Determine number of retrieved (possibly split) system spans.
+        n_retrieved = 0
+        for ref_ids in self.sys_to_refs:
+            if ref_ids:
+                n_retrieved += len(ref_ids)
+            else:
+                # Include spurious/incorrect spans
+                n_retrieved += 1
+        return self.relevance_score / n_retrieved
+
+    @cached_property
+    def recall(self) -> float:
+        """
+        Calculate page-level recall. Edge case: If there are no reference spans,
+        return 1 if there are also no system spans and 0 otherwise.
+        """
+        if not self.ref_spans:
+            # Edge case to avoid divide by zero error
+            return 1 if not self.sys_spans else 0
+
+        n_relevant = len(self.ref_spans)
+        return self.relevance_score / n_relevant
+
+
+def get_page_span_evaluation():
+    raise NotImplementedError
+
+
+def get_page_evals(ref_file, sys_file):
+    raise NotImplementedError
+
+
+def write_page_evals(ref_file, sys_file, out_file):
+    raise NotImplementedError

--- a/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
+++ b/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
@@ -521,7 +521,9 @@ def test_get_page_evals(mock_get_page_eval, tmp_path):
     sys_file.write_text(sys_jsonl)
     mock_get_page_eval.side_effect = ["A", "B"]
 
-    results = list(get_page_evals(ref_file, sys_file, ignore_label="flag"))
+    results = list(
+        get_page_evals(ref_file, sys_file, ignore_label="flag", disable_progress=True)
+    )
     assert results == ["A", "B"]
     assert mock_get_page_eval.call_count == 2
     expected_calls = [
@@ -556,9 +558,10 @@ def test_write_page_evals(mock_get_page_evals, tmp_path):
         out_csv,
         ignore_label="bool",
         partial_match_weight="weight",
+        disable_progress="bool",
     )
     mock_get_page_evals.assert_called_once_with(
-        "ref_file", "sys_file", ignore_label="bool"
+        "ref_file", "sys_file", ignore_label="bool", disable_progress="bool"
     )
     page_eval_a.precision.assert_called_once_with(partial_match_weight="weight")
     page_eval_a.recall.assert_called_once_with(partial_match_weight="weight")

--- a/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
+++ b/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
@@ -141,7 +141,6 @@ class TestSpan:
         mock_overlap_length.assert_called_once_with(span_b, ignore_label="bool")
         ## partial overlap
         mock_has_overlap.reset_mock()
-        mock_has_overlap.return_value = True
         mock_overlap_length.reset_mock()
         mock_overlap_length.return_value = 2
         span_b = Span(3, 5, "label")
@@ -164,12 +163,10 @@ class TestPageReferenceSpans:
         mock_get_spans.assert_called_once_with(page_json)
 
     def test_get_spans(self):
-        # Note: Initialization calls _get_spans
-
         # No spans
         page_json = {"page_id": "id", "n_excerpts": 0}
-        result = PageReferenceSpans(page_json)
-        assert result.spans == []
+        result = PageReferenceSpans._get_spans(page_json)
+        assert result == []
 
         # With spans
         excerpts = [
@@ -179,15 +176,15 @@ class TestPageReferenceSpans:
             {"start": 1, "end": 3, "poem_id": "c"},
         ]
         page_json = {"page_id": "id", "n_excerpts": 4, "excerpts": excerpts}
-        result = PageReferenceSpans(page_json)
+        result = PageReferenceSpans._get_spans(page_json)
         expected_spans = [
             Span(0, 5, "c"),
             Span(1, 3, "c"),
             Span(1, 8, "b"),
             Span(3, 4, "a"),
         ]
-        assert len(result.spans) == 4
-        for i, span in enumerate(result.spans):
+        assert len(result) == 4
+        for i, span in enumerate(result):
             assert span == expected_spans[i]
 
 
@@ -205,14 +202,11 @@ class TestPageSystemSpans:
         mock_get_labeled_spans.assert_called_once_with(page_json)
         mock_get_unlabeled_spans.assert_called_once()
 
-    @patch.object(PageSystemSpans, "_get_unlabeled_spans")
-    def test_get_labeled_spans(self, mock_get_unlabeled_spans):
-        # Note: Initialization calls _get_labeled_spans & _get_unlabeled_spans
-
+    def test_get_labeled_spans(self):
         # No spans
         page_json = {"page_id": "id", "n_spans": 0}
-        result = PageSystemSpans(page_json)
-        assert result.labeled_spans == []
+        result = PageSystemSpans._get_labeled_spans(page_json)
+        assert result == []
 
         # With spans
         poem_spans = [
@@ -222,38 +216,34 @@ class TestPageSystemSpans:
             {"page_start": 1, "page_end": 3, "ref_id": "c"},
         ]
         page_json = {"page_id": "id", "n_spans": 4, "poem_spans": poem_spans}
-        result = PageSystemSpans(page_json)
+        result = PageSystemSpans._get_labeled_spans(page_json)
         expected_spans = [
             Span(0, 5, "c"),
             Span(1, 3, "c"),
             Span(1, 8, "b"),
             Span(3, 4, "a"),
         ]
-        assert len(result.labeled_spans) == 4
-        for i, span in enumerate(result.labeled_spans):
+        assert len(result) == 4
+        for i, span in enumerate(result):
             assert span == expected_spans[i]
 
-    @patch.object(PageSystemSpans, "_get_labeled_spans")
-    def test_get_unlabeled_spans(self, mock_get_labeled_spans):
-        # Note: Initialization calls _get_labeled_spans & _get_unlabeled_spans
-
+    def test_get_unlabeled_spans(self):
         # No spans
-        mock_get_labeled_spans.return_value = []
-        result = PageSystemSpans({"page_id": "id"})
-        assert result.unlabeled_spans == []
+        result = PageSystemSpans._get_unlabeled_spans([])
+        assert result == []
 
         # With spans
-        mock_get_labeled_spans.return_value = [
+        labeled_spans = [
             Span(0, 1, "a"),
             Span(1, 4, "a"),
             Span(2, 3, "b"),
             Span(3, 5, "d"),
             Span(9, 10, "a"),
         ]
-        result = PageSystemSpans({"page_id": "id"})
+        result = PageSystemSpans._get_unlabeled_spans(labeled_spans)
         expected_spans = [Span(0, 1, ""), Span(1, 5, ""), Span(9, 10, "")]
-        assert len(result.unlabeled_spans) == 3
-        for i, span in enumerate(result.unlabeled_spans):
+        assert len(result) == 3
+        for i, span in enumerate(result):
             assert span == expected_spans[i]
 
 
@@ -298,12 +288,7 @@ class TestPageEvaluation:
 
         # Ignore labels
         mock_get_span_mappings.reset_mock()
-        mock_get_span_mappings.return_value = (
-            "ref span --> sys span",
-            "sys span --> ref spans",
-        )
         mock_get_span_pairs.reset_mock()
-        mock_get_span_pairs.return_value = "span pairs"
         result = PageEvaluation(page_ref_spans, page_sys_spans, ignore_label=True)
         assert result.ignore_label == True
         assert result.ref_spans == "spans"
@@ -315,68 +300,190 @@ class TestPageEvaluation:
         mock_get_span_pairs.assert_called_once()
 
     def test_get_span_mappings(self):
-        # TODO
-        pass
+        # Simple 1-1 cases
+        ref_spans = [Span(2, 5, "a"), Span(10, 15, "b")]
+        sys_spans = [Span(1, 6, "a"), Span(11, 13, "c")]
+        ## Label sensitive
+        results = PageEvaluation._get_span_mappings(ref_spans, sys_spans, False)
+        assert results[0] == [0, None]
+        assert results[1] == [[0], []]
+        ## Label insensitive
+        results = PageEvaluation._get_span_mappings(ref_spans, sys_spans, True)
+        assert results[0] == [0, 1]
+        assert results[1] == [[0], [1]]
 
-    def test_get_spain_pairs(self):
-        # TODO
-        pass
+        # Best overlap
+        ref_spans = [Span(3, 8, "a")]
+        sys_spans = [Span(1, 4, "a"), Span(4, 7, "a"), Span(7, 10, "a")]
+        for ignore_label in [False, True]:
+            results = PageEvaluation._get_span_mappings(
+                ref_spans, sys_spans, ignore_label
+            )
+            assert results[0] == [1]
+            assert results[1] == [[], [0], []]
 
-    def test_relevance_score(self):
-        # TODO
-        pass
+        # System span mapping to multiple reference spans
+        ref_spans = [Span(2, 5, "a"), Span(7, 11, "b"), Span(18, 20, "a")]
+        sys_spans = [Span(0, 25, "a")]
+        ## Label sensitive
+        results = PageEvaluation._get_span_mappings(ref_spans, sys_spans, False)
+        assert results[0] == [0, None, 0]
+        assert results[1] == [[0, 2]]
+        ## Label insensitive
+        results = PageEvaluation._get_span_mappings(ref_spans, sys_spans, True)
+        assert results[0] == [0, 0, 0]
+        assert results[1] == [[0, 1, 2]]
 
+    def test_get_span_pairs(self):
+        # Simple 1-1 case
+        ref_spans = ["a", "b", "c"]
+        sys_spans = ["A", "_", "C", "_"]
+        sys_to_refs = [[0], [], [2], []]
+        result = PageEvaluation._get_span_pairs(ref_spans, sys_spans, sys_to_refs)
+        assert result == [("a", "A"), ("c", "C")]
+
+        # Requires system span splitting
+        ## System span maps to two reference spans
+        ref_spans = [Span(0, 3, "a"), Span(10, 12, "b"), Span(15, 17, "b")]
+        sys_spans = [Span(0, 3, "A"), Span(8, 25, "B")]
+        sys_to_refs = [[0], [1, 2]]
+        expected_result = [
+            (ref_spans[0], Span(0, 3, "A")),
+            (ref_spans[1], Span(8, 15, "B")),
+            (ref_spans[2], Span(15, 25, "B")),
+        ]
+        result = PageEvaluation._get_span_pairs(ref_spans, sys_spans, sys_to_refs)
+        assert result == expected_result
+
+    @patch.object(Span, "overlap_factor")
+    @patch.object(Span, "is_exact_match")
+    def test_relevance_score(self, mock_is_exact_match, mock_overlap_factor):
+        # test pairs (note the actual values are not used directly in test)
+        span_pairs = [
+            (Span(0, 1, "a"), Span(0, 1, "A")),
+            (Span(1, 2, "b"), Span(1, 2, "B")),
+            (Span(2, 3, "c"), Span(2, 3, "C")),
+        ]
+        # Only exact matches
+        mock_is_exact_match.return_value = True
+        result = PageEvaluation._relevance_score(
+            span_pairs, "ignore_label", "partial_weight"
+        )
+        assert result == 3
+        assert mock_is_exact_match.call_count == 3
+        mock_overlap_factor.assert_not_called()
+
+        # With partial matches
+        ## No downweighting
+        mock_is_exact_match.reset_mock()
+        mock_is_exact_match.side_effect = [True, False, False]
+        mock_overlap_factor.reset_mock()
+        mock_overlap_factor.side_effect = [0.2, 0.3]
+        result = PageEvaluation._relevance_score(span_pairs, "ignore_label", 1)
+        assert result == 1.5
+        assert mock_is_exact_match.call_count == 3
+        assert mock_overlap_factor.call_count == 2
+        ## With downweighting
+        mock_is_exact_match.reset_mock()
+        mock_is_exact_match.side_effect = [True, False, False]
+        mock_overlap_factor.reset_mock()
+        mock_overlap_factor.side_effect = [0.2, 0.3]
+        result = PageEvaluation._relevance_score(span_pairs, "ignore_label", 0.5)
+        assert result == 1.25
+
+    def test_retrieved_count(self):
+        # Simple matches
+        assert PageEvaluation._retrieved_count([[]]) == 1
+        assert PageEvaluation._retrieved_count([[1]]) == 1
+        assert PageEvaluation._retrieved_count([[3], []]) == 2
+        assert PageEvaluation._retrieved_count([[], [1], [5]]) == 3
+
+        # System span covers matches multiple reference spans
+        assert PageEvaluation._retrieved_count([[3, 5]]) == 2
+        assert PageEvaluation._retrieved_count([[], [1, 2, 3], [6]]) == 5
+
+    @patch.object(PageEvaluation, "_relevance_score")
+    @patch.object(PageEvaluation, "_retrieved_count")
     @patch.object(PageEvaluation, "_get_span_pairs")
     @patch.object(PageEvaluation, "_get_span_mappings")
-    @patch.object(PageEvaluation, "relevance_score", 0.5)
-    def test_precision(self, mock_span_mapping, mock_span_pairs):
-        mock_span_mapping.return_value = "", ""
-        mock_span_pairs.return_value = ""
+    def test_precision(
+        self, mock_span_mappings, mock_span_pairs, mock_retrieved_count, mock_relevance
+    ):
+        mock_span_mappings.return_value = "", "sys_to_refs"
+        mock_span_pairs.return_value = "span_pairs"
         # Edge case: No system spans
         page_sys_spans = NonCallableMock(page_id="id", labeled_spans=[])
         ## With reference spans
         page_ref_spans = NonCallableMock(page_id="id", spans=["s"])
         page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.precision == 0
+        assert page_eval.precision() == 0
+        mock_retrieved_count.assert_not_called()
+        mock_relevance.assert_not_called()
         ## No reference spans
         page_ref_spans = NonCallableMock(page_id="id", spans=[])
         page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.precision == 1
+        assert page_eval.precision() == 1
+        mock_retrieved_count.assert_not_called()
+        mock_relevance.assert_not_called()
 
         # With system spans
-        sys_to_refs = [[], [0]]
-        mock_span_mapping.return_value = "", sys_to_refs
+        mock_retrieved_count.return_value = 2
+        mock_relevance.return_value = 0.5
         page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"] * 2)
-        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.precision == 0.5 / 2
-        sys_to_refs = [[], [1, 2], [3], [4, 5, 6]]
-        mock_span_mapping.return_value = "", sys_to_refs
-        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"] * 4)
-        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.precision == 0.5 / 7
+        page_eval = PageEvaluation(
+            page_ref_spans, page_sys_spans, ignore_label="ignore_label"
+        )
+        assert page_eval.precision(partial_match_weight="weight") == 0.5 / 2
+        mock_retrieved_count.assert_called_once_with("sys_to_refs")
+        mock_relevance.assert_called_once_with("span_pairs", "ignore_label", "weight")
 
+        mock_retrieved_count.reset_mock()
+        mock_retrieved_count.return_value = 7
+        mock_relevance.reset_mock()
+        mock_relevance.return_value = 4.5
+        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"] * 4)
+        page_eval = PageEvaluation(
+            page_ref_spans, page_sys_spans, ignore_label="ignore_label"
+        )
+        assert page_eval.precision(partial_match_weight="weight") == 4.5 / 7
+        mock_retrieved_count.assert_called_once_with("sys_to_refs")
+        mock_relevance.assert_called_once_with("span_pairs", "ignore_label", "weight")
+
+    @patch.object(PageEvaluation, "_relevance_score")
     @patch.object(PageEvaluation, "_get_span_pairs")
     @patch.object(PageEvaluation, "_get_span_mappings")
-    @patch.object(PageEvaluation, "relevance_score", 0.5)
-    def test_recall(self, mock_span_mapping, mock_span_pairs):
-        mock_span_mapping.return_value = "", ""
-        mock_span_pairs.return_value = ""
+    def test_recall(self, mock_span_mappings, mock_span_pairs, mock_relevance):
+        # Mocking needed for PageEvaluation initialization
+        mock_span_mappings.return_value = "", ""
+        mock_span_pairs.return_value = "span_pairs"
 
         # Edge case: No reference spans
         page_ref_spans = NonCallableMock(page_id="id", spans=[])
         ## With system spans
         page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"])
         page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.recall == 0
+        assert page_eval.recall() == 0
+        mock_relevance.assert_not_called()
         ## No system spans
         page_sys_spans = NonCallableMock(page_id="id", labeled_spans=[])
         page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.recall == 1
+        assert page_eval.recall() == 1
+        mock_relevance.assert_not_called()
 
         # With reference spans
+        mock_relevance.return_value = 0.5
         page_ref_spans = NonCallableMock(page_id="id", spans=["a"])
-        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.recall == 0.5 / 1
+        page_eval = PageEvaluation(
+            page_ref_spans, page_sys_spans, ignore_label="ignore_label"
+        )
+        assert page_eval.recall(partial_match_weight="weight") == 0.5 / 1
+        mock_relevance.assert_called_once_with("span_pairs", "ignore_label", "weight")
+
+        mock_relevance.reset_mock()
+        mock_relevance.return_value = 2.1
         page_ref_spans = NonCallableMock(page_id="id", spans=["a"] * 3)
-        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
-        assert page_eval.recall == 0.5 / 3
+        page_eval = PageEvaluation(
+            page_ref_spans, page_sys_spans, ignore_label="ignore_label"
+        )
+        assert page_eval.recall(partial_match_weight="weight") == 2.1 / 3
+        mock_relevance.assert_called_once_with("span_pairs", "ignore_label", "weight")

--- a/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
+++ b/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
@@ -1,0 +1,382 @@
+import sys
+from unittest.mock import NonCallableMock, call, patch
+
+import pytest
+
+from corppa.poetry_detection.evaluation.evaluate_poetry_spans import (
+    PageEvaluation,
+    PageReferenceSpans,
+    PageSystemSpans,
+    Span,
+)
+
+
+class TestSpan:
+    def test_init(self):
+        # Invalid range: end index < start index
+        error_message = "Start index must be less than end index"
+        with pytest.raises(ValueError, match=error_message):
+            span = Span(9, 2, "label")
+        # Invalid range: end index = < start index
+        with pytest.raises(ValueError, match=error_message):
+            span = Span(2, 2, "label")
+
+        # Normal case
+        span = Span(2, 5, "label")
+        assert span.start == 2
+        assert span.end == 5
+        assert span.label == "label"
+
+    def test_len(self):
+        assert len(Span(2, 5, "label")) == 3
+        assert len(Span(0, 42, "label")) == 42
+
+    def test_eq(self):
+        span_a = Span(3, 6, "label")
+        assert span_a == Span(3, 6, "label")
+        assert span_a != Span(4, 8, "label")
+        assert span_a != Span(3, 6, "different")
+
+    def test_repr(self):
+        span_a = Span(3, 6, "label")
+        assert repr(span_a) == "Span(3, 6, label)"
+
+    def test_has_overlap(self):
+        span_a = Span(3, 6, "label")
+
+        for label in ["label", "different"]:
+            ## exact overlap
+            span_b = Span(3, 6, label)
+            assert span_a.has_overlap(span_b) == (label == "label")
+            assert span_a.has_overlap(span_b, ignore_label=True)
+            ## partial overlap: subsets
+            span_b = Span(4, 5, label)
+            assert span_a.has_overlap(span_b) == (label == "label")
+            assert span_a.has_overlap(span_b, ignore_label=True)
+            span_b = Span(3, 5, label)
+            assert span_a.has_overlap(span_b) == (label == "label")
+            assert span_a.has_overlap(span_b, ignore_label=True)
+            span_b = Span(4, 6, label)
+            assert span_a.has_overlap(span_b) == (label == "label")
+            assert span_a.has_overlap(span_b, ignore_label=True)
+            ## partial overlap: not subsets
+            span_b = Span(1, 5, label)
+            assert span_a.has_overlap(span_b) == (label == "label")
+            assert span_a.has_overlap(span_b, ignore_label=True)
+            span_b = Span(4, 8, label)
+            assert span_a.has_overlap(span_b) == (label == "label")
+            assert span_a.has_overlap(span_b, ignore_label=True)
+            ## no overlap
+            span_b = Span(0, 1, label)
+            assert not span_a.has_overlap(span_b)
+            assert not span_a.has_overlap(span_b, ignore_label=True)
+            span_b = Span(0, 3, label)
+            assert not span_a.has_overlap(span_b)
+            assert not span_a.has_overlap(span_b, ignore_label=True)
+
+    def test_is_exact_match(self):
+        span_a = Span(3, 6, "label")
+
+        for label in ["label", "different"]:
+            # exact overlap
+            span_b = Span(3, 6, label)
+            assert span_a.is_exact_match(span_b) == (label == "label")
+            assert span_a.is_exact_match(span_b, ignore_label=True)
+            # partial overlap
+            span_b = Span(3, 5, label)
+            assert not span_a.is_exact_match(span_b)
+            assert not span_a.is_exact_match(span_b, ignore_label=True)
+            span_b = Span(2, 8, label)
+            assert not span_a.is_exact_match(span_b)
+            assert not span_a.is_exact_match(span_b, ignore_label=True)
+            # no overlap
+            span_b = Span(0, 1, label)
+            assert not span_a.is_exact_match(span_b)
+            assert not span_a.is_exact_match(span_b, ignore_label=True)
+            span_b = Span(0, 3, label)
+            assert not span_a.is_exact_match(span_b)
+            assert not span_a.is_exact_match(span_b, ignore_label=True)
+
+    @patch.object(Span, "has_overlap")
+    def test_overlap_length(self, mock_has_overlap):
+        span_a = Span(3, 6, "label")
+
+        # no overlap
+        mock_has_overlap.return_value = False
+        assert span_a.overlap_length("other span", ignore_label="bool") == 0
+        mock_has_overlap.assert_called_once_with("other span", ignore_label="bool")
+
+        # has overlap
+        mock_has_overlap.reset_mock()
+        mock_has_overlap.return_value = True
+        ## exact overlap
+        span_b = Span(3, 6, "label")
+        assert span_a.overlap_length(span_b) == 3
+        mock_has_overlap.assert_called_once_with(span_b, ignore_label=False)
+        ## partial overlap
+        span_b = Span(3, 5, "label")
+        assert span_a.overlap_length(span_b) == 2
+        span_b = Span(2, 8, "label")
+        assert span_a.overlap_length(span_b) == 3
+
+    @patch.object(Span, "has_overlap")
+    @patch.object(Span, "overlap_length")
+    def test_overlap_factor(self, mock_overlap_length, mock_has_overlap):
+        span_a = Span(3, 6, "label")
+
+        # no overlap
+        mock_has_overlap.return_value = False
+        assert span_a.overlap_factor("other span", ignore_label="bool") == 0
+        mock_has_overlap.assert_called_once_with("other span", ignore_label="bool")
+        mock_overlap_length.assert_not_called()
+
+        # has overlap
+        mock_has_overlap.reset_mock()
+        mock_has_overlap.return_value = True
+        mock_overlap_length.return_value = 3
+        ## exact overlap
+        span_b = Span(3, 6, "label")
+        assert span_a.overlap_factor(span_b, ignore_label="bool") == 1
+        mock_has_overlap.assert_called_once_with(span_b, ignore_label="bool")
+        mock_overlap_length.assert_called_once_with(span_b, ignore_label="bool")
+        ## partial overlap
+        mock_has_overlap.reset_mock()
+        mock_has_overlap.return_value = True
+        mock_overlap_length.reset_mock()
+        mock_overlap_length.return_value = 2
+        span_b = Span(3, 5, "label")
+        assert span_a.overlap_factor(span_b) == 2 / 3
+        mock_has_overlap.assert_called_once_with(span_b, ignore_label=False)
+        mock_overlap_length.assert_called_once_with(span_b, ignore_label=False)
+        span_b = Span(2, 8, "label")
+        mock_overlap_length.return_value = 3
+        assert span_a.overlap_factor(span_b) == 3 / 6
+
+
+class TestPageReferenceSpans:
+    @patch.object(PageReferenceSpans, "_get_spans")
+    def test_init(self, mock_get_spans):
+        mock_get_spans.return_value = "spans list"
+        page_json = {"page_id": "12345"}
+        result = PageReferenceSpans(page_json)
+        assert result.page_id == "12345"
+        assert result.spans == "spans list"
+        mock_get_spans.assert_called_once_with(page_json)
+
+    def test_get_spans(self):
+        # Note: Initialization calls _get_spans
+
+        # No spans
+        page_json = {"page_id": "id", "n_excerpts": 0}
+        result = PageReferenceSpans(page_json)
+        assert result.spans == []
+
+        # With spans
+        excerpts = [
+            {"start": 0, "end": 5, "poem_id": "c"},
+            {"start": 3, "end": 4, "poem_id": "a"},
+            {"start": 1, "end": 8, "poem_id": "b"},
+            {"start": 1, "end": 3, "poem_id": "c"},
+        ]
+        page_json = {"page_id": "id", "n_excerpts": 4, "excerpts": excerpts}
+        result = PageReferenceSpans(page_json)
+        expected_spans = [
+            Span(0, 5, "c"),
+            Span(1, 3, "c"),
+            Span(1, 8, "b"),
+            Span(3, 4, "a"),
+        ]
+        assert len(result.spans) == 4
+        for i, span in enumerate(result.spans):
+            assert span == expected_spans[i]
+
+
+class TestPageSystemSpans:
+    @patch.object(PageSystemSpans, "_get_unlabeled_spans")
+    @patch.object(PageSystemSpans, "_get_labeled_spans")
+    def test_init(self, mock_get_labeled_spans, mock_get_unlabeled_spans):
+        mock_get_labeled_spans.return_value = "labeled spans list"
+        mock_get_unlabeled_spans.return_value = "unlabeled spans list"
+        page_json = {"page_id": "12345"}
+        result = PageSystemSpans(page_json)
+        assert result.page_id == "12345"
+        assert result.labeled_spans == "labeled spans list"
+        assert result.unlabeled_spans == "unlabeled spans list"
+        mock_get_labeled_spans.assert_called_once_with(page_json)
+        mock_get_unlabeled_spans.assert_called_once()
+
+    @patch.object(PageSystemSpans, "_get_unlabeled_spans")
+    def test_get_labeled_spans(self, mock_get_unlabeled_spans):
+        # Note: Initialization calls _get_labeled_spans & _get_unlabeled_spans
+
+        # No spans
+        page_json = {"page_id": "id", "n_spans": 0}
+        result = PageSystemSpans(page_json)
+        assert result.labeled_spans == []
+
+        # With spans
+        poem_spans = [
+            {"page_start": 0, "page_end": 5, "ref_id": "c"},
+            {"page_start": 3, "page_end": 4, "ref_id": "a"},
+            {"page_start": 1, "page_end": 8, "ref_id": "b"},
+            {"page_start": 1, "page_end": 3, "ref_id": "c"},
+        ]
+        page_json = {"page_id": "id", "n_spans": 4, "poem_spans": poem_spans}
+        result = PageSystemSpans(page_json)
+        expected_spans = [
+            Span(0, 5, "c"),
+            Span(1, 3, "c"),
+            Span(1, 8, "b"),
+            Span(3, 4, "a"),
+        ]
+        assert len(result.labeled_spans) == 4
+        for i, span in enumerate(result.labeled_spans):
+            assert span == expected_spans[i]
+
+    @patch.object(PageSystemSpans, "_get_labeled_spans")
+    def test_get_unlabeled_spans(self, mock_get_labeled_spans):
+        # Note: Initialization calls _get_labeled_spans & _get_unlabeled_spans
+
+        # No spans
+        mock_get_labeled_spans.return_value = []
+        result = PageSystemSpans({"page_id": "id"})
+        assert result.unlabeled_spans == []
+
+        # With spans
+        mock_get_labeled_spans.return_value = [
+            Span(0, 1, "a"),
+            Span(1, 4, "a"),
+            Span(2, 3, "b"),
+            Span(3, 5, "d"),
+            Span(9, 10, "a"),
+        ]
+        result = PageSystemSpans({"page_id": "id"})
+        expected_spans = [Span(0, 1, ""), Span(1, 5, ""), Span(9, 10, "")]
+        assert len(result.unlabeled_spans) == 3
+        for i, span in enumerate(result.unlabeled_spans):
+            assert span == expected_spans[i]
+
+
+class TestPageEvaluation:
+    @patch.object(PageEvaluation, "_get_span_pairs")
+    @patch.object(PageEvaluation, "_get_span_mappings")
+    def test_init(self, mock_get_span_mappings, mock_get_span_pairs):
+        # Page id mismatch
+        page_ref_spans = NonCallableMock(page_id="a")
+        page_sys_spans = NonCallableMock(page_id="b")
+        with pytest.raises(
+            ValueError,
+            match="Reference and system spans must correspond to the same page",
+        ):
+            PageEvaluation(page_ref_spans, page_sys_spans)
+            mock_get_span_mappings.assert_not_called()
+            mock_get_span_pairs.assert_not_called()
+
+        # Setup for non-error cases
+        page_ref_spans = NonCallableMock(page_id="id", spans="spans")
+        page_sys_spans = NonCallableMock(
+            page_id="id",
+            labeled_spans="labeled spans",
+            unlabeled_spans="unlabeled spans",
+        )
+
+        # Default case (ignore_label = False)
+        mock_get_span_mappings.return_value = (
+            "ref span --> sys span",
+            "sys span --> ref spans",
+        )
+        mock_get_span_pairs.return_value = "span pairs"
+        result = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert result.ignore_label == False
+        assert result.ref_spans == "spans"
+        assert result.sys_spans == "labeled spans"
+        assert result.ref_to_sys == "ref span --> sys span"
+        assert result.sys_to_refs == "sys span --> ref spans"
+        assert result.span_pairs == "span pairs"
+        mock_get_span_mappings.assert_called_once()
+        mock_get_span_pairs.assert_called_once()
+
+        # Ignore labels
+        mock_get_span_mappings.reset_mock()
+        mock_get_span_mappings.return_value = (
+            "ref span --> sys span",
+            "sys span --> ref spans",
+        )
+        mock_get_span_pairs.reset_mock()
+        mock_get_span_pairs.return_value = "span pairs"
+        result = PageEvaluation(page_ref_spans, page_sys_spans, ignore_label=True)
+        assert result.ignore_label == True
+        assert result.ref_spans == "spans"
+        assert result.sys_spans == "unlabeled spans"
+        assert result.ref_to_sys == "ref span --> sys span"
+        assert result.sys_to_refs == "sys span --> ref spans"
+        assert result.span_pairs == "span pairs"
+        mock_get_span_mappings.assert_called_once()
+        mock_get_span_pairs.assert_called_once()
+
+    def test_get_span_mappings(self):
+        # TODO
+        pass
+
+    def test_get_spain_pairs(self):
+        # TODO
+        pass
+
+    def test_relevance_score(self):
+        # TODO
+        pass
+
+    @patch.object(PageEvaluation, "_get_span_pairs")
+    @patch.object(PageEvaluation, "_get_span_mappings")
+    @patch.object(PageEvaluation, "relevance_score", 0.5)
+    def test_precision(self, mock_span_mapping, mock_span_pairs):
+        mock_span_mapping.return_value = "", ""
+        mock_span_pairs.return_value = ""
+        # Edge case: No system spans
+        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=[])
+        ## With reference spans
+        page_ref_spans = NonCallableMock(page_id="id", spans=["s"])
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.precision == 0
+        ## No reference spans
+        page_ref_spans = NonCallableMock(page_id="id", spans=[])
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.precision == 1
+
+        # With system spans
+        sys_to_refs = [[], [0]]
+        mock_span_mapping.return_value = "", sys_to_refs
+        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"] * 2)
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.precision == 0.5 / 2
+        sys_to_refs = [[], [1, 2], [3], [4, 5, 6]]
+        mock_span_mapping.return_value = "", sys_to_refs
+        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"] * 4)
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.precision == 0.5 / 7
+
+    @patch.object(PageEvaluation, "_get_span_pairs")
+    @patch.object(PageEvaluation, "_get_span_mappings")
+    @patch.object(PageEvaluation, "relevance_score", 0.5)
+    def test_recall(self, mock_span_mapping, mock_span_pairs):
+        mock_span_mapping.return_value = "", ""
+        mock_span_pairs.return_value = ""
+
+        # Edge case: No reference spans
+        page_ref_spans = NonCallableMock(page_id="id", spans=[])
+        ## With system spans
+        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=["s"])
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.recall == 0
+        ## No system spans
+        page_sys_spans = NonCallableMock(page_id="id", labeled_spans=[])
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.recall == 1
+
+        # With reference spans
+        page_ref_spans = NonCallableMock(page_id="id", spans=["a"])
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.recall == 0.5 / 1
+        page_ref_spans = NonCallableMock(page_id="id", spans=["a"] * 3)
+        page_eval = PageEvaluation(page_ref_spans, page_sys_spans)
+        assert page_eval.recall == 0.5 / 3


### PR DESCRIPTION
Here is the current code for evaluating span annotations.

The script requires two key files to run, page-level JSONL files that contain reference and system span annotations.

Usage: `python evaluate_poetry_spans ref_jsonl sys_jsonl out.csv`

Note that I'm considering adding reporting for the following:
- number of exact matches
- number of partial matches
- number of missed reference spans
- number of spurious system spans