### PR TITLE
Configure test paths for pytest to speed up test collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ collate-txt = "corppa.ocr.collate_txt:main"
 [tool.hatch.version]
 path = "src/corppa/__init__.py"
 
+[tool.pytest.ini_options]
+testpaths = ["test"]
+
 [tool.ruff]
 # configure src path so ruff import fixes can identify local imports
 src = ["src"]


### PR DESCRIPTION
I noticed when trying to run tests on the poem excerpt branch that collecting tests was really slow. Specifying the test paths as a pytest config option speeds it up significantly.