### PR TITLE
Customize codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default: false  # disable default status check
+      all:  # custom target for app+tests
+        # target: auto
+        target: 75  # override auto target since current coverage is lower
+      tests:  # declare a new status context  for "tests"
+        target: 100%  # we always want 100% coverage here
+        paths:
+          - "test/"  # only include coverage in "tests/" folder
+
+

--- a/test/test_poetry_detection/test_annotation/test_annotation_recipes.py
+++ b/test/test_poetry_detection/test_annotation/test_annotation_recipes.py
@@ -277,8 +277,8 @@ class TestReviewStream:
             match="Cannot create review example without one or more annotated versions",
         ):
             ReviewStream.create_review_example([])
-            mock_get_session_name.assert_not_called()
-            mock_add_session_prefix.assert_not_called()
+        mock_get_session_name.assert_not_called()
+        mock_add_session_prefix.assert_not_called()
 
         # Single, minimal example
         mock_get_session_name.return_value = "session_name"


### PR DESCRIPTION
This PR adds a codecov configuration file so we can customize the defaults.

I've turned off the default check and added one for tests that requires 100% coverage (and I fixed one more instance of nested assertions that caused it to fail), and one for app+tests that requires 75% coverage (which we're currently just over).  It would be more logical for the second one to be just app but I thought setting coverage at 53% would be kind of demoralizing.

We can adjust our targets and checks as code coverage improves. 