### PR TITLE
Add chart to show how system span is split for multiple reference spans

### DIFF
--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -75,7 +75,26 @@ $$
 \left(r_{k_{start}}, s_{end} \right)
 $$
 
+
+```mermaid
+block-beta
+columns 12
+space:1
+Sys["System Span"]:9
+space:2
+Ref1["Ref Span 1"]:3
+space:1
+Ref2["Ref Span 2"]:3
+Ref3["Ref Span 3"]:4
+space:2
+SysSub1["System Sub 1"]:3
+SysSub2["System Sub 2"]:3
+SysSub3["System Sub 3"]:3
+```
+
 **Example.**
+
+
 If we have the following four reference spans $(394, 512), (516, 557), (563, 633), (637, 675)$ mapped
 to the system span $(389, 678)$, this will result in the following working reference-system span pairs:
 

--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -61,9 +61,9 @@ b["Span b"]:7
 space:2
 overlap:4
 
-style a fill:green
-style b fill:blue
-style overlap fill:purple
+style a fill:#147416
+style b fill:#11149C
+style overlap fill:#481E66
 ```
 
 
@@ -98,23 +98,23 @@ $$
 ```mermaid
 block-beta
 columns 12
-Ref1["Ref Span 1"]:3
+Ref0["Ref Span 0"]:3
 space:1
+Ref1["Ref Span 1"]:3
 Ref2["Ref Span 2"]:3
-Ref3["Ref Span 3"]:3
 space:2
 space:1
 Sys["System Span"]:10 
 space:1
 space:1
+SysSub0["System Sub 0"]:3
 SysSub1["System Sub 1"]:3
-SysSub2["System Sub 2"]:3
-SysSub3["System Sub 3"]:4
+SysSub2["System Sub 2"]:4
 
-style Sys fill:#484
-style SysSub1 fill:#484
-style SysSub2 fill:#484
-style SysSub3 fill:#484
+style Sys fill:#147416
+style SysSub0 fill:#147416
+style SysSub1 fill:#147416
+style SysSub2 fill:#147416
 
 ```
 

--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -79,17 +79,24 @@ $$
 ```mermaid
 block-beta
 columns 12
-space:1
-Sys["System Span"]:9
-space:2
 Ref1["Ref Span 1"]:3
 space:1
 Ref2["Ref Span 2"]:3
-Ref3["Ref Span 3"]:4
+Ref3["Ref Span 3"]:3
 space:2
+space:1
+Sys["System Span"]:10 
+space:1
+space:1
 SysSub1["System Sub 1"]:3
 SysSub2["System Sub 2"]:3
-SysSub3["System Sub 3"]:3
+SysSub3["System Sub 3"]:4
+
+style Sys fill:#484
+style SysSub1 fill:#484
+style SysSub2 fill:#484
+style SysSub3 fill:#484
+
 ```
 
 **Example.**

--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -61,9 +61,9 @@ b["Span b"]:7
 space:2
 overlap:4
 
-style a fill:#147416
-style b fill:#11149C
-style overlap fill:#481E66
+style a fill:#147416,color:#fff
+style b fill:#11149C,color:#fff
+style overlap fill:#481E66,color:#fff
 ```
 
 
@@ -111,12 +111,14 @@ SysSub0["System Sub 0"]:3
 SysSub1["System Sub 1"]:3
 SysSub2["System Sub 2"]:4
 
-style Sys fill:#147416
-style SysSub0 fill:#147416
-style SysSub1 fill:#147416
-style SysSub2 fill:#147416
+style Sys fill:#147416,color:#fff
+style SysSub0 fill:#147416,color:#fff
+style SysSub1 fill:#147416,color:#fff
+style SysSub2 fill:#147416,color:#fff
 
 ```
+The full system span is sliced up into subspans and paired with the closest reference span; all portions of the system span are used across the subspans. (Gaps between subspans in the chart are not meant to indicate gaps in content.)
+
 
 **Example.**
 

--- a/src/corppa/poetry_detection/evaluation/README.md
+++ b/src/corppa/poetry_detection/evaluation/README.md
@@ -48,6 +48,25 @@ $$
 overlap\textunderscore factor(a, b) = \frac{\min(a_{end}, b_{end}) - \max(a_{start}, b_{start})}{\max(a_{end}-a_{start}, b_{end}-b_{start})}
 $$
 
+
+For example, if we have **span a** with length 5 and **span b** with length 7 and a and b have an overlap 4, the overlap factor for a and b would be $\frac{4}{7}$, since span b is the longer of the two spans.
+
+```mermaid
+block-beta
+columns 9
+a["Span a"]:5
+space:3
+space:2
+b["Span b"]:7
+space:2
+overlap:4
+
+style a fill:green
+style b fill:blue
+style overlap fill:purple
+```
+
+
 ### Step 1. Map reference spans to viable system spans
 In this first step, we take inspiration from ACE NER evaluation metrics (see Hal Daume's [blog post comment](https://nlpers.blogspot.com/2006/08/doing-named-entity-recognition-dont.html?showComment=1156981200000#c115698122985619877)). We effectively build a bipartite graph linking
 each reference span to the "best" matching system span. Currently, we determine the best matching

--- a/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
+++ b/test/test_poetry_detection/test_evaluation/test_evaluate_poetry_spans.py
@@ -120,8 +120,8 @@ class TestPageEvaluation:
             match="Reference and system spans must correspond to the same page",
         ):
             PageEvaluation(page_ref_spans, page_sys_spans)
-            mock_get_span_mappings.assert_not_called()
-            mock_get_span_pairs.assert_not_called()
+        mock_get_span_mappings.assert_not_called()
+        mock_get_span_pairs.assert_not_called()
 
         # Setup for non-error cases
         page_ref_spans = NonCallableMock(page_id="id", spans="spans")


### PR DESCRIPTION
Adds a visual representation of how spans are split into subspans pairs for evaluation using a mermaid chart.

I couldn't figure out how to add comments to explain what's going on, but I'm using column width and spaces to try to convey how these spans overlap.

You can preiew the chart here: https://github.com/Princeton-CDH/ppa-nlp/tree/sysrefspan-chart/src/corppa/poetry_detection/evaluation

I think I may have switched system and reference spans - although I was trying to follow the numeric example you provided. Please confirm and let me know if you see anything else that should be revised and I'll address.