### PR TITLE
Feature/feature/add excerpt ids

### DIFF
--- a/src/corppa/poetry_detection/annotation/process_adjudication_data.py
+++ b/src/corppa/poetry_detection/annotation/process_adjudication_data.py
@@ -134,7 +134,6 @@ def process_adjudication_data(
             page_data = process_page_annotation(page_anno)
 
             # Write excerpt-level data
-            print(page_data)
             for excerpt in page_data["excerpts"]:
                 csv_writer.writerow(excerpt.to_csv())
 

--- a/src/corppa/poetry_detection/annotation/process_adjudication_data.py
+++ b/src/corppa/poetry_detection/annotation/process_adjudication_data.py
@@ -24,52 +24,24 @@ import argparse
 import csv
 import pathlib
 import sys
-from collections.abc import Generator
-from typing import Any, TypedDict
+from collections.abc import Iterable
+from typing import Any
 
 import orjsonl
 from tqdm import tqdm
 from xopen import xopen
 
-
-class Excerpt(TypedDict):
-    """
-    Basic excerpt object, primarily used for type checking
-    """
-
-    start: int
-    end: int
-    text: str
-
-
-def clean_excerpt(span: Excerpt) -> Excerpt:
-    """
-    Clean excerpt so that any leading and trailing whitespace is removed. This involves
-    updating the excerpt text itself as well as its start and end indices.
-    """
-    updated_span = span.copy()
-    # Remove any leading whitespace
-    ldiff = len(span["text"]) - len(span["text"].lstrip())
-    if ldiff:
-        updated_span["start"] = span["start"] + ldiff
-        updated_span["text"] = updated_span["text"][ldiff:]
-    # Remove any trailing whitespace
-    rdiff = len(span["text"]) - len(span["text"].rstrip())
-    if rdiff:
-        updated_span["end"] = span["end"] - rdiff
-        updated_span["text"] = updated_span["text"][:-rdiff]
-    return updated_span
+from corppa.poetry_detection.core import Excerpt
 
 
 def get_excerpts(page_annotation: dict[str, Any]) -> list[Excerpt]:
     """
     Extract excerpts from page-level annotation. Excerpts have the following
-    fields:
         * start: character-level starting index
         * end: character-level end index (Pythonic, exclusive)
         * text: text of page excerpt
 
-    Note: Currently ignoring span labels, since there's only one for the
+    Note: This ignores span labels since there's only one for the
           poetry detection task.
     """
     excerpts = []
@@ -78,12 +50,14 @@ def get_excerpts(page_annotation: dict[str, Any]) -> list[Excerpt]:
     if "spans" not in page_annotation:
         raise ValueError("Page annotation missing 'spans' field")
     for span in page_annotation["spans"]:
-        excerpt: Excerpt = {
-            "start": span["start"],
-            "end": span["end"],
-            "text": page_text[span["start"] : span["end"]],
-        }
-        excerpts.append(clean_excerpt(excerpt))
+        excerpt = Excerpt(
+            page_id=page_annotation["id"],
+            ppa_span_start=span["start"],
+            ppa_span_end=span["end"],
+            ppa_span_text=page_text[span["start"] : span["end"]],
+            detection_methods={"adjudication"},
+        )
+        excerpts.append(excerpt.strip_whitespace())
     return excerpts
 
 
@@ -110,23 +84,22 @@ def process_page_annotation(page_annotation) -> dict[str, Any]:
     return page_data
 
 
-def get_excerpt_entries(page_data: dict[str, Any]) -> Generator[dict[str, Any]]:
+def simplify_excerpts(excerpts: Iterable[Excerpt]) -> list[dict[str, Any]]:
     """
-    Generate excerpt entries data from the processed page produced by
-    `process_page_annotation`.
+    Converts excerpts into a simplified form with the following fields:
+        * start = starting index of PPA span
+        * end = ending index of PPA span
+        * text = text of PPA span
     """
-    for excerpt in page_data["excerpts"]:
-        entry = {
-            "page_id": page_data["page_id"],
-            "work_id": page_data["work_id"],
-            "work_title": page_data["work_title"],
-            "work_author": page_data["work_author"],
-            "work_year": page_data["work_year"],
-            "start": excerpt["start"],
-            "end": excerpt["end"],
-            "text": excerpt["text"],
+    simplified_excerpts = []
+    for excerpt in excerpts:
+        simple_excerpt = {
+            "start": excerpt.ppa_span_start,
+            "end": excerpt.ppa_span_end,
+            "text": excerpt.ppa_span_text,
         }
-        yield entry
+        simplified_excerpts.append(simple_excerpt)
+    return simplified_excerpts
 
 
 def process_adjudication_data(
@@ -147,24 +120,29 @@ def process_adjudication_data(
     )
     csv_fieldnames = [
         "page_id",
-        "work_id",
-        "work_title",
-        "work_author",
-        "work_year",
-        "start",
-        "end",
-        "text",
+        "excerpt_id",
+        "ppa_span_start",
+        "ppa_span_end",
+        "ppa_span_text",
+        "detection_methods",
+        "notes",
     ]
     with open(output_excerpts, mode="w", newline="") as csvfile:
         csv_writer = csv.DictWriter(csvfile, fieldnames=csv_fieldnames)
         csv_writer.writeheader()
         for page_anno in progress_annos:
-            # Get & save page data
             page_data = process_page_annotation(page_anno)
-            orjsonl.append(output_pages, page_data)
 
-            for row in get_excerpt_entries(page_data):
-                csv_writer.writerow(row)
+            # Write excerpt-level data
+            print(page_data)
+            for excerpt in page_data["excerpts"]:
+                csv_writer.writerow(excerpt.to_csv())
+
+            # Simplify excerpts
+            # TODO: This is needed for compatiblity with existing evaluation code
+            page_data["excerpts"] = simplify_excerpts(page_data["excerpts"])
+            # Write page-level data
+            orjsonl.append(output_pages, page_data)
 
 
 def main():

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -179,7 +179,7 @@ class Excerpt:
             if ", " in detection_methods:
                 input_args["detection_methods"] = set(detection_methods.split(", "))
             else:
-                input_args["detection_methods"] = set(detection_methods)
+                input_args["detection_methods"] = {detection_methods}
         else:
             raise ValueError("Unexpected value type for detection_methods")
         return Excerpt(**input_args)

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -150,7 +150,7 @@ class Excerpt:
         Returns a CSV-friendly dict of the poem excerpt. Unlike `to_dict`, unset optional
         fields are included and set to empty strings.
         """
-        csv_dict = {}
+        csv_dict: dict[str, int | str] = {}
         for key, value in asdict(self).items():
             if value is None:
                 # Set unset fields as empty strings
@@ -250,4 +250,4 @@ class LabeledExcerpt(Excerpt):
                 input_args[fieldname] = frozenset(value.split(", "))
             else:
                 raise ValueError(f"Unexpected value type for {fieldname}")
-            return Excerpt(**input_args)
+        return LabeledExcerpt(**input_args)

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -2,7 +2,7 @@
 Custom data type for poetry excerpts identified with the text of PPA pages.
 """
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from typing import Any, Optional
 
 # Would upper casing be better?
@@ -134,6 +134,21 @@ class Excerpt:
                 else:
                     json_dict[key] = value
         return json_dict
+
+    def strip_whitespace(self) -> "Excerpt":
+        """
+        Returns a copy of the excerpt such that leading and trailing whitespace
+        have been removed from the text. In addition to the text, the start
+        and end indices will also be updated.
+        """
+        ldiff = len(self.ppa_span_text) - len(self.ppa_span_text.lstrip())
+        rdiff = len(self.ppa_span_text) - len(self.ppa_span_text.rstrip())
+        return replace(
+            self,
+            ppa_span_start=self.ppa_span_start + ldiff,
+            ppa_span_end=self.ppa_span_end - rdiff,
+            ppa_span_text=self.ppa_span_text.strip(),
+        )
 
 
 @dataclass(kw_only=True)

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -135,6 +135,23 @@ class Excerpt:
                     json_dict[key] = value
         return json_dict
 
+    def to_csv(self) -> dict[str, int | str]:
+        """
+        Returns a CSV-friendly dict of the poem excerpt. Unlike `to_dict`, unset optional
+        fields are included and set to empty strings.
+        """
+        csv_dict = {}
+        for key, value in asdict(self).items():
+            if value is None:
+                # Set unset fields as empty strings
+                csv_dict[key] = ""
+            elif type(value) is set:
+                # Convert sets to comma-separated lists
+                csv_dict[key] = ", ".join(value)
+            else:
+                csv_dict[key] = value
+        return csv_dict
+
     def strip_whitespace(self) -> "Excerpt":
         """
         Returns a copy of the excerpt such that leading and trailing whitespace

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -3,7 +3,16 @@ Custom data type for poetry excerpts identified with the text of PPA pages.
 """
 
 from dataclasses import asdict, dataclass
+from functools import cached_property
 from typing import Any, Optional
+
+# Would upper casing be better?
+DETECTION_PFX_TABLE = {
+    "adjudication": "a",
+    "manual": "m",
+    "passim": "p",
+    "xml": "x",
+}
 
 
 @dataclass
@@ -95,6 +104,20 @@ class Excerpt:
             raise ValueError(
                 f"PPA span's start index {self.ppa_span_start} must be less than its end index {self.ppa_span_end}"
             )
+
+    @cached_property
+    def excerpt_id(self):
+        if len(self.detection_methods) > 1:
+            raise NotImplementedError(
+                "IDs for excerpts with multiple detection methods are currently undefined"
+            )
+        else:
+            [detect_name] = self.detection_methods
+            # Should this validation occur instead within post_init?
+            if detect_name not in DETECTION_PFX_TABLE:
+                raise ValueError(f"Unsupported detection method '{detect_name}'")
+            detect_pfx = DETECTION_PFX_TABLE[detect_name]
+            return f"{detect_pfx}@{self.ppa_span_start}:{self.ppa_span_end}"
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -154,9 +154,8 @@ class Excerpt:
 
     def strip_whitespace(self) -> "Excerpt":
         """
-        Returns a copy of the excerpt such that leading and trailing whitespace
-        have been removed from the text. In addition to the text, the start
-        and end indices will also be updated.
+        Return a copy of this excerpt with any leading and trailing whitespace
+        removed from the text and start and end indices updated to match any changes.
         """
         ldiff = len(self.ppa_span_text) - len(self.ppa_span_text.lstrip())
         rdiff = len(self.ppa_span_text) - len(self.ppa_span_text.rstrip())

--- a/src/corppa/poetry_detection/passim/README.md
+++ b/src/corppa/poetry_detection/passim/README.md
@@ -94,9 +94,9 @@ python get_passim_page_results.py ppa_text.jsonl passim-output passim_page_resul
 ```
 
 ### 4. Build excerpt-level results
-Finally, an excerpt-level results file (TSV) can be built from the page-level results
+Finally, an excerpt-level results file (CSV) can be built from the page-level results
 *with excerpts* built in the previous step using `get_passim_excerpts.py`.
 
 ```
-python get_passim_excerpts.py passim_page_results.jsonl passim_excerpts.tsv
+python get_passim_excerpts.py passim_page_results.jsonl passim_excerpts.csv
 ```

--- a/src/corppa/poetry_detection/passim/get_passim_excerpts.py
+++ b/src/corppa/poetry_detection/passim/get_passim_excerpts.py
@@ -4,65 +4,82 @@ Gather excerpts from passim page-level results.
 
 import argparse
 import csv
-import pathlib
 import sys
+from collections.abc import Generator
+from pathlib import Path
 
 import orjsonl
 
+from corppa.poetry_detection.core import LabeledExcerpt
 
-def get_passage_matches(input_file):
+
+def get_passim_excerpts(input_file: Path) -> Generator[LabeledExcerpt]:
     """
-    Extracts and yields the passim-identified passage-level matches
+    Extracts and yields the passim-identified passage-level excerpts
     """
     for page in orjsonl.stream(input_file):
         if not page["n_spans"]:
             # Skipe pages without matches
             continue
+        page_id = page["page_id"]
         for poem_span in page["poem_spans"]:
-            match = poem_span.copy()
-            match["page_id"] = page["page_id"]
-            yield match
+            excerpt = LabeledExcerpt(
+                page_id=page_id,
+                ppa_span_start=poem_span["page_start"],
+                ppa_span_end=poem_span["page_end"],
+                ppa_span_text=poem_span["page_excerpt"],
+                detection_methods={"passim"},
+                poem_id=poem_span["ref_id"],
+                ref_corpus=poem_span["ref_corpus"],
+                ref_span_start=poem_span["ref_start"],
+                ref_span_end=poem_span["ref_end"],
+                ref_span_text=poem_span["ref_excerpt"],
+                identification_methods={"passim"},
+            )
+            yield excerpt
 
 
-def save_passim_passage_matches(input_file, output_file):
-    with open(output_file, mode="w", newline="") as tsvfile:
+def save_passim_excerpts(input_file: Path, output_file: Path) -> None:
+    with open(output_file, mode="w", newline="") as csvfile:
         fieldnames = [
             "page_id",
-            "ref_id",
+            "excerpt_id",
+            "ppa_span_start",
+            "ppa_span_end",
+            "ppa_span_text",
+            "poem_id",
             "ref_corpus",
-            "page_start",
-            "page_end",
-            "ref_start",
-            "ref_end",
-            "page_excerpt",
-            "ref_excerpt",
-            "aligned_page_excerpt",
-            "aligned_ref_excerpt",
+            "ref_span_start",
+            "ref_span_end",
+            "ref_span_text",
+            "detection_methods",
+            "identification_methods",
+            "notes",
         ]
-        writer = csv.DictWriter(tsvfile, fieldnames=fieldnames, dialect="excel-tab")
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
-        for match in get_passage_matches(input_file):
-            writer.writerow(match)
+        for excerpt in get_passim_excerpts(input_file):
+            writer.writerow(excerpt.to_csv())
 
 
 def main():
     """
-    Command-line access to build TSV file of passage-level passim matches.
+    Command-line access to build CSV file of passage-level passim matches.
     """
     parser = argparse.ArgumentParser(
-        description="Extract passage-level passim results (TSV)"
+        description="Extract passage-level passim results (CSV)"
     )
 
     # Required arguments
     parser.add_argument(
         "input",
         help="Page-level passim results file (JSONL)",
-        type=pathlib.Path,
+        type=Path,
     )
     parser.add_argument(
         "output",
-        help="Filename for passage-level passim output (TSV)",
-        type=pathlib.Path,
+        help="Filename for passage-level passim output (CSV)",
+        type=Path,
     )
 
     args = parser.parse_args()
@@ -75,7 +92,7 @@ def main():
         print(f"Error: output file {args.output} exist", file=sys.stderr)
         sys.exit(1)
 
-    save_passim_passage_matches(args.input, args.output)
+    save_passim_excerpts(args.input, args.output)
 
 
 if __name__ == "__main__":

--- a/test/test_poetry_detection/test_annotation/test_process_adjudication_data.py
+++ b/test/test_poetry_detection/test_annotation/test_process_adjudication_data.py
@@ -168,8 +168,13 @@ def test_process_adjudication_data(
     ]
     excerpts_csv_form = [e.to_csv() for e in excerpts]
     csv_text = ",".join(csv_fields) + "\n"
-    csv_text += ",".join([f"{excerpts_csv_form[0][f]}" for f in csv_fields]) + "\n"
-    csv_text += ",".join([f"{excerpts_csv_form[1][f]}" for f in csv_fields]) + "\n"
+    # Note: notes field is uninitialized
+    csv_text += (
+        ",".join([f"{excerpts_csv_form[0][f]}" for f in csv_fields[:-1]]) + ",\n"
+    )
+    csv_text += (
+        ",".join([f"{excerpts_csv_form[1][f]}" for f in csv_fields[:-1]]) + ",\n"
+    )
     assert out_csv.read_text(encoding="utf-8") == csv_text
 
     # Disable progress

--- a/test/test_poetry_detection/test_annotation/test_process_adjudication_data.py
+++ b/test/test_poetry_detection/test_annotation/test_process_adjudication_data.py
@@ -5,42 +5,16 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from corppa.poetry_detection.annotation.process_adjudication_data import (
-    clean_excerpt,
-    get_excerpt_entries,
     get_excerpts,
     process_adjudication_data,
     process_page_annotation,
+    simplify_excerpts,
 )
+from corppa.poetry_detection.core import Excerpt
 
 
-def test_clean_excerpt():
-    # No leading or trailing whitespace
-    span = {"start": 1, "end": 12, "text": "hello world"}
-    assert clean_excerpt(span) == span
-
-    # Leading whitespace
-    span = {"start": 0, "end": 13, "text": "\r\nhello world"}
-    expected_result = {"start": 2, "end": 13, "text": "hello world"}
-    assert clean_excerpt(span) == expected_result
-
-    # Trailing whitespace
-    span = {"start": 0, "end": 13, "text": "hello world\t "}
-    expected_result = {"start": 0, "end": 11, "text": "hello world"}
-    assert clean_excerpt(span) == expected_result
-
-    # Leading and trailing whitespace
-    span = {
-        "start": 0,
-        "end": 13,
-        "text": " hello world\n",
-    }
-    expected_result = {"start": 1, "end": 12, "text": "hello world"}
-    assert clean_excerpt(span) == expected_result
-
-
-@patch("corppa.poetry_detection.annotation.process_adjudication_data.clean_excerpt")
-def test_get_excerpts(mock_clean_excerpt):
-    page_annotation = {"text": "some page text"}
+def test_get_excerpts():
+    page_annotation = {"id": "page_id", "text": "some page text"}
 
     # Missing spans field
     with pytest.raises(ValueError, match="Page annotation missing 'spans' field"):
@@ -49,26 +23,31 @@ def test_get_excerpts(mock_clean_excerpt):
     # Empty spans field
     page_annotation["spans"] = []
     assert get_excerpts(page_annotation) == []
-    mock_clean_excerpt.assert_not_called()
-
-    # Regular case (i.e. non-empty spans field)
-    mock_clean_excerpt.side_effect = lambda x: x
-    page_annotation["spans"].append({"start": 0, "end": 4})
-    page_annotation["spans"].append({"start": 10, "end": 14})
-    results = get_excerpts(page_annotation)
-    assert results[0] == {"start": 0, "end": 4, "text": "some"}
-    assert results[1] == {"start": 10, "end": 14, "text": "text"}
-    assert mock_clean_excerpt.call_count == 2
-    mock_clean_excerpt.assert_has_calls(
-        [
-            call({"start": 0, "end": 4, "text": "some"}),
-            call({"start": 10, "end": 14, "text": "text"}),
-        ]
-    )
 
     # Missing text field
     blank_page = {"spans": []}
     assert get_excerpts(blank_page) == []
+
+    # Typical case
+    page_annotation["spans"].append({"start": 0, "end": 4})
+    page_annotation["spans"].append({"start": 9, "end": 14})
+    results = get_excerpts(page_annotation)
+    ## No whitespace stripping
+    assert results[0] == Excerpt(
+        page_id="page_id",
+        ppa_span_start=0,
+        ppa_span_end=4,
+        ppa_span_text="some",
+        detection_methods={"adjudication"},
+    )
+    # Whitespace stripping occurs
+    assert results[1] == Excerpt(
+        page_id="page_id",
+        ppa_span_start=10,
+        ppa_span_end=14,
+        ppa_span_text="text",
+        detection_methods={"adjudication"},
+    )
 
 
 @patch("corppa.poetry_detection.annotation.process_adjudication_data.get_excerpts")
@@ -93,29 +72,31 @@ def test_process_page_annotation(mock_get_excerpts):
     mock_get_excerpts.assert_called_once_with(page_annotation)
 
 
-def test_get_excerpt_entries():
-    page_meta = {
-        "page_id": "some-page-id",
-        "work_id": "some-work-id",
-        "work_title": "some-title",
-        "work_author": "some-author",
-        "work_year": "some-year",
-    }
+def test_simplify_excerpts():
     excerpts = [
-        {"start": 0, "end": 3, "text": "a"},
-        {"start": 5, "end": 6, "text": "b"},
+        Excerpt(
+            page_id="0",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="a",
+            detection_methods={"adjudication"},
+        ),
+        Excerpt(
+            page_id="1",
+            ppa_span_start=1,
+            ppa_span_end=2,
+            ppa_span_text="b",
+            detection_methods={"adjudication"},
+        ),
     ]
-    page_data = page_meta | {"excerpts": excerpts}
-    expected_results = [page_meta | excerpt for excerpt in excerpts]
+    expected_results = [
+        {"start": 0, "end": 1, "text": "a"},
+        {"start": 1, "end": 2, "text": "b"},
+    ]
+    assert simplify_excerpts(excerpts) == expected_results
 
-    result = get_excerpt_entries(page_data)
-    assert isgenerator(result)
-    assert list(result) == expected_results
 
-
-@patch(
-    "corppa.poetry_detection.annotation.process_adjudication_data.get_excerpt_entries"
-)
+@patch("corppa.poetry_detection.annotation.process_adjudication_data.simplify_excerpts")
 @patch(
     "corppa.poetry_detection.annotation.process_adjudication_data.process_page_annotation"
 )
@@ -125,52 +106,84 @@ def test_process_adjudication_data(
     mock_tqdm,
     mock_orjsonl,
     mock_process_page_annotation,
-    mock_get_excerpt_entries,
+    mock_simplify_excerpts,
     tmpdir,
 ):
     input_jsonl = tmpdir / "input.jsonl"
     input_jsonl.write_text("some\ntext\n", encoding="utf-8")
-    out_excerpts = tmpdir / "output.csv"
+    out_csv = tmpdir / "output.csv"
 
-    # Default
-    csv_fields = [
-        "page_id",
-        "work_id",
-        "work_title",
-        "work_author",
-        "work_year",
-        "start",
-        "end",
-        "text",
+    excerpts = [
+        Excerpt(
+            page_id="a",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="a",
+            detection_methods={"adjudication"},
+        ),
+        Excerpt(
+            page_id="b",
+            ppa_span_start=1,
+            ppa_span_end=2,
+            ppa_span_text="b",
+            detection_methods={"adjudication"},
+        ),
     ]
+
+    # Default case
+    ## Mock setup
     mock_orjsonl.stream.return_value = "jsonl stream"
     mock_tqdm.return_value = ["a", "b"]
-    mock_process_page_annotation.side_effect = lambda x: f"page {x}"
-    mock_get_excerpt_entries.return_value = [{k: "test" for k in csv_fields}]
+    mock_process_page_annotation.side_effect = [
+        {"page_id": "a", "excerpts": [excerpts[0]]},
+        {"page_id": "b", "excerpts": [excerpts[1]]},
+    ]
+    mock_simplify_excerpts.side_effect = ["excerpts a", "excerpts b"]
 
-    process_adjudication_data(input_jsonl, "out.jsonl", out_excerpts)
+    process_adjudication_data(input_jsonl, "out.jsonl", out_csv)
+    ## Verify mock calls
     mock_orjsonl.stream.assert_called_once_with(input_jsonl)
     mock_tqdm.assert_called_once_with("jsonl stream", total=2, disable=False)
     assert mock_process_page_annotation.call_count == 2
     mock_process_page_annotation.assert_has_calls([call("a"), call("b")])
+    assert mock_simplify_excerpts.call_count == 2
+    mock_simplify_excerpts.assert_has_calls([call(excerpts[0:1]), call(excerpts[-1:])])
     assert mock_orjsonl.append.call_count == 2
     mock_orjsonl.append.assert_has_calls(
-        [call("out.jsonl", "page a"), call("out.jsonl", "page b")]
+        [
+            call("out.jsonl", {"page_id": "a", "excerpts": "excerpts a"}),
+            call("out.jsonl", {"page_id": "b", "excerpts": "excerpts b"}),
+        ]
     )
-    assert mock_get_excerpt_entries.call_count == 2
-    mock_get_excerpt_entries.assert_has_calls([call("page a"), call("page b")])
+
+    ## Verify excerpt-level CSV output
+    csv_fields = [
+        "page_id",
+        "excerpt_id",
+        "ppa_span_start",
+        "ppa_span_end",
+        "ppa_span_text",
+        "detection_methods",
+        "notes",
+    ]
+    excerpts_csv_form = [e.to_csv() for e in excerpts]
     csv_text = ",".join(csv_fields) + "\n"
-    csv_text += ",".join(["test"] * 8) + "\n"
-    csv_text += ",".join(["test"] * 8) + "\n"
-    assert out_excerpts.read_text(encoding="utf-8") == csv_text
+    csv_text += ",".join([f"{excerpts_csv_form[0][f]}" for f in csv_fields]) + "\n"
+    csv_text += ",".join([f"{excerpts_csv_form[1][f]}" for f in csv_fields]) + "\n"
+    assert out_csv.read_text(encoding="utf-8") == csv_text
 
     # Disable progress
+    ## Reset mocks
     mock_orjsonl.reset_mock()
     mock_orjsonl.stream.return_value = "jsonl stream"
     mock_tqdm.reset_mock()
     mock_tqdm.return_value = ["a", "b"]
-    process_adjudication_data(
-        input_jsonl, "out.jsonl", out_excerpts, disable_progress=True
-    )
+    mock_process_page_annotation.side_effect = [
+        {"page_id": "a", "excerpts": [excerpts[0]]},
+        {"page_id": "b", "excerpts": [excerpts[1]]},
+    ]
+    mock_simplify_excerpts.side_effect = ["excerpts a", "excerpts b"]
+    ## Limit testing to disabling progress
+    process_adjudication_data(input_jsonl, "out.jsonl", out_csv, disable_progress=True)
     mock_orjsonl.stream.assert_called_once_with(input_jsonl)
     mock_tqdm.assert_called_once_with("jsonl stream", total=2, disable=True)

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -251,7 +251,6 @@ class TestExcerpt:
             "ppa_span_text": "page_text",
             "detection_methods": "manual",
             "excerpt_id": "m@0:1",
-            "notes": "",
         }
 
         result = excerpt.to_csv()
@@ -277,7 +276,7 @@ class TestExcerpt:
         assert Excerpt.from_dict(jsonl_dict) == excerpt
 
         # CSV-friendly dict
-        csv_dict = excerpt.to_dict()
+        csv_dict = excerpt.to_csv()
         assert Excerpt.from_dict(csv_dict) == excerpt
 
         # Error if detection_methods field has bad type
@@ -494,7 +493,7 @@ class TestLabeledExcerpt:
         assert LabeledExcerpt.from_dict(jsonl_dict) == excerpt
 
         # CSV-friendly dict
-        csv_dict = excerpt.to_dict()
+        csv_dict = excerpt.to_csv()
         assert LabeledExcerpt.from_dict(csv_dict) == excerpt
 
         # Error if detection or identification methods fields have bad type

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -276,6 +276,11 @@ class TestExcerpt:
         assert Excerpt.from_dict(jsonl_dict) == excerpt
 
         # CSV-friendly dict
+        ## Multiple detection methods
+        csv_dict = excerpt.to_csv()
+        assert Excerpt.from_dict(csv_dict) == excerpt
+        ## Single detection methods
+        excerpt = replace(excerpt, detection_methods={"adjudication"})
         csv_dict = excerpt.to_csv()
         assert Excerpt.from_dict(csv_dict) == excerpt
 

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -226,6 +226,75 @@ class TestExcerpt:
         result = excerpt.to_dict()
         assert result == expected_result
 
+    def test_strip_whitespace(self):
+        # No leading or trailing whitespace
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=1,
+            ppa_span_end=12,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        expected_result = Excerpt(
+            page_id="page_id",
+            ppa_span_start=1,
+            ppa_span_end=12,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        assert excerpt.strip_whitespace() == expected_result
+
+        # Leading whitespace
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=13,
+            ppa_span_text="\r\npage_text",
+            detection_methods={"manual"},
+        )
+        expected_result = Excerpt(
+            page_id="page_id",
+            ppa_span_start=2,
+            ppa_span_end=13,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        assert excerpt.strip_whitespace() == expected_result
+
+        # Trailing whitespace
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=13,
+            ppa_span_text="page_text\t ",
+            detection_methods={"manual"},
+        )
+        expected_result = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=11,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        assert excerpt.strip_whitespace() == expected_result
+
+        # Leading & trailing whitespace
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=13,
+            ppa_span_text=" page_text\n",
+            detection_methods={"manual"},
+        )
+        expected_result = Excerpt(
+            page_id="page_id",
+            ppa_span_start=1,
+            ppa_span_end=12,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        assert excerpt.strip_whitespace() == expected_result
+
 
 class TestLabeledExcerpt:
     def test_init(self):

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -161,6 +161,33 @@ class TestExcerpt:
                 detection_methods={},
             )
 
+    def test_excerpt_id(self):
+        # Typical case
+        for detection_method in ["adjudication", "manual", "passim", "xml"]:
+            excerpt = Excerpt(
+                page_id="page_id",
+                ppa_span_start=0,
+                ppa_span_end=1,
+                ppa_span_text="page_text",
+                detection_methods={detection_method},
+            )
+            expected_result = f"{detection_method[0]}@0:1"
+            assert excerpt.excerpt_id == expected_result
+
+        # Raises error for multiple excerpts
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="page_text",
+            detection_methods={"adjudication", "passim"},
+        )
+        error_message = (
+            "IDs for excerpts with multiple detection methods are currently undefined"
+        )
+        with pytest.raises(NotImplementedError, match=error_message):
+            excerpt.excerpt_id
+
     def test_to_dict(self):
         # No optional fields
         excerpt = Excerpt(

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -226,6 +226,35 @@ class TestExcerpt:
         result = excerpt.to_dict()
         assert result == expected_result
 
+    def test_to_csv(self):
+        # No optional fields
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        expected_result = {
+            "page_id": "page_id",
+            "ppa_span_start": 0,
+            "ppa_span_end": 1,
+            "ppa_span_text": "page_text",
+            "detection_methods": "manual",
+            "excerpt_id": "m@0:1",
+            "notes": "",
+        }
+
+        result = excerpt.to_csv()
+        assert result == expected_result
+
+        # With optional fields
+        excerpt.notes = "notes"
+        expected_result["notes"] = "notes"
+
+        result = excerpt.to_csv()
+        assert result == expected_result
+
     def test_strip_whitespace(self):
         # No leading or trailing whitespace
         excerpt = Excerpt(

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -478,14 +478,17 @@ class TestLabeledExcerpt:
         result = excerpt.to_dict()
         assert result == expected_result
 
-    def from_dict(self):
+    def test_from_dict(self):
         # JSONL-friendly dict
         excerpt = LabeledExcerpt(
             page_id="page_id",
             ppa_span_start=0,
             ppa_span_end=1,
             ppa_span_text="page_text",
-            detection_methods={"manual", "xml"},
+            poem_id="poem_id",
+            ref_corpus="poems",
+            detection_methods={"adjudication", "manual"},
+            identification_methods={"manual", "matcha"},
         )
         jsonl_dict = excerpt.to_dict()
         assert LabeledExcerpt.from_dict(jsonl_dict) == excerpt

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -174,6 +174,18 @@ class TestExcerpt:
             expected_result = f"{detection_method[0]}@0:1"
             assert excerpt.excerpt_id == expected_result
 
+        # Raises error for unknown detection method
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="page_text",
+            detection_methods={"unknown"},
+        )
+        error_message = "Unsupported detection method 'unknown'"
+        with pytest.raises(ValueError, match=error_message):
+            excerpt.excerpt_id
+
         # Raises error for multiple excerpts
         excerpt = Excerpt(
             page_id="page_id",

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -156,13 +156,24 @@ class TestExcerpt:
             excerpt = Excerpt(
                 page_id="page_id",
                 ppa_span_start=0,
-                ppa_span_end=0,
+                ppa_span_end=1,
                 ppa_span_text="page_text",
                 detection_methods={},
             )
 
+        # Invalid, single detect method
+        error_message = "Unsupported detection method 'unknown'"
+        with pytest.raises(ValueError, match=error_message):
+            excerpt = Excerpt(
+                page_id="page_id",
+                ppa_span_start=0,
+                ppa_span_end=1,
+                ppa_span_text="page_text",
+                detection_methods={"unknown"},
+            )
+
     def test_excerpt_id(self):
-        # Typical case
+        # Single detection method
         for detection_method in ["adjudication", "manual", "passim", "xml"]:
             excerpt = Excerpt(
                 page_id="page_id",
@@ -174,19 +185,7 @@ class TestExcerpt:
             expected_result = f"{detection_method[0]}@0:1"
             assert excerpt.excerpt_id == expected_result
 
-        # Raises error for unknown detection method
-        excerpt = Excerpt(
-            page_id="page_id",
-            ppa_span_start=0,
-            ppa_span_end=1,
-            ppa_span_text="page_text",
-            detection_methods={"unknown"},
-        )
-        error_message = "Unsupported detection method 'unknown'"
-        with pytest.raises(ValueError, match=error_message):
-            excerpt.excerpt_id
-
-        # Raises error for multiple excerpts
+        # Multiple detection methods
         excerpt = Excerpt(
             page_id="page_id",
             ppa_span_start=0,
@@ -194,11 +193,7 @@ class TestExcerpt:
             ppa_span_text="page_text",
             detection_methods={"adjudication", "passim"},
         )
-        error_message = (
-            "IDs for excerpts with multiple detection methods are currently undefined"
-        )
-        with pytest.raises(NotImplementedError, match=error_message):
-            excerpt.excerpt_id
+        assert excerpt.excerpt_id == "mult@0:1"
 
     def test_to_dict(self):
         # No optional fields
@@ -207,14 +202,15 @@ class TestExcerpt:
             ppa_span_start=0,
             ppa_span_end=1,
             ppa_span_text="page_text",
-            detection_methods={"detect"},
+            detection_methods={"manual"},
         )
         expected_result = {
             "page_id": "page_id",
             "ppa_span_start": 0,
             "ppa_span_end": 1,
             "ppa_span_text": "page_text",
-            "detection_methods": ["detect"],
+            "detection_methods": ["manual"],
+            "excerpt_id": "m@0:1",
         }
 
         result = excerpt.to_dict()
@@ -243,7 +239,7 @@ class TestLabeledExcerpt:
                 ppa_span_text="page_text",
                 poem_id="poem_id",
                 ref_corpus="corpus_id",
-                detection_methods={"detect"},
+                detection_methods={"manual"},
                 identification_methods={"id"},
                 ref_span_start=0,
             )
@@ -255,7 +251,7 @@ class TestLabeledExcerpt:
                 ppa_span_text="page_text",
                 poem_id="poem_id",
                 ref_corpus="corpus_id",
-                detection_methods={"detect"},
+                detection_methods={"manual"},
                 identification_methods={"id"},
                 ref_span_end=1,
             )
@@ -271,7 +267,7 @@ class TestLabeledExcerpt:
                 ppa_span_text="page_text",
                 poem_id="poem_id",
                 ref_corpus="corpus_id",
-                detection_methods={"detect"},
+                detection_methods={"manual"},
                 identification_methods={"id"},
                 ref_span_start=0,
                 ref_span_end=0,
@@ -287,7 +283,7 @@ class TestLabeledExcerpt:
                 ppa_span_text="page_text",
                 poem_id="poem_id",
                 ref_corpus="corpus_id",
-                detection_methods={"detect"},
+                detection_methods={"manual"},
                 identification_methods={"id"},
                 ref_span_start=1,
                 ref_span_end=0,
@@ -299,11 +295,11 @@ class TestLabeledExcerpt:
             excerpt = LabeledExcerpt(
                 page_id="page_id",
                 ppa_span_start=0,
-                ppa_span_end=0,
+                ppa_span_end=1,
                 ppa_span_text="page_text",
                 poem_id="poem_id",
                 ref_corpus="corpus_id",
-                detection_methods={"detect"},
+                detection_methods={"manual"},
                 identification_methods={},
             )
 
@@ -316,7 +312,7 @@ class TestLabeledExcerpt:
             ppa_span_text="page_text",
             poem_id="poem_id",
             ref_corpus="corpus_id",
-            detection_methods={"detect"},
+            detection_methods={"manual"},
             identification_methods={"id"},
         )
         expected_result = {
@@ -326,8 +322,9 @@ class TestLabeledExcerpt:
             "ppa_span_text": "page_text",
             "poem_id": "poem_id",
             "ref_corpus": "corpus_id",
-            "detection_methods": ["detect"],
+            "detection_methods": ["manual"],
             "identification_methods": ["id"],
+            "excerpt_id": "m@0:1",
         }
 
         result = excerpt.to_dict()

--- a/test/test_poetry_detection/test_passim/test_get_passim_excerpts.py
+++ b/test/test_poetry_detection/test_passim/test_get_passim_excerpts.py
@@ -120,6 +120,9 @@ def test_save_passim_excerpts(mock_get_excerpts, tmpdir):
             detection_methods={"passim"},
             poem_id="poem",
             ref_corpus="ref",
+            ref_span_start=0,
+            ref_span_end=3,
+            ref_span_text="ABC",
             identification_methods={"passim"},
         ),
         LabeledExcerpt(
@@ -130,6 +133,9 @@ def test_save_passim_excerpts(mock_get_excerpts, tmpdir):
             detection_methods={"passim"},
             poem_id="poem",
             ref_corpus="ref",
+            ref_span_start=10,
+            ref_span_end=13,
+            ref_span_text="abc",
             identification_methods={"passim"},
         ),
     ]
@@ -137,3 +143,30 @@ def test_save_passim_excerpts(mock_get_excerpts, tmpdir):
     mock_get_excerpts.return_value = iter(test_excerpts)
     save_passim_excerpts("input", out_csv)
     mock_get_excerpts.assert_called_once_with("input")
+
+    # Verify CSV output
+    csv_fields = [
+        "page_id",
+        "excerpt_id",
+        "ppa_span_start",
+        "ppa_span_end",
+        "ppa_span_text",
+        "poem_id",
+        "ref_corpus",
+        "ref_span_start",
+        "ref_span_end",
+        "ref_span_text",
+        "detection_methods",
+        "identification_methods",
+        "notes",
+    ]
+    excerpts_csv_form = [e.to_csv() for e in test_excerpts]
+    csv_text = ",".join(csv_fields) + "\n"
+    # Note: notes field is uninitialized
+    csv_text += (
+        ",".join([f"{excerpts_csv_form[0][f]}" for f in csv_fields[:-1]]) + ",\n"
+    )
+    csv_text += (
+        ",".join([f"{excerpts_csv_form[1][f]}" for f in csv_fields[:-1]]) + ",\n"
+    )
+    assert out_csv.read_text(encoding="utf-8") == csv_text

--- a/test/test_poetry_detection/test_passim/test_get_passim_excerpts.py
+++ b/test/test_poetry_detection/test_passim/test_get_passim_excerpts.py
@@ -1,0 +1,139 @@
+from unittest.mock import patch
+
+from corppa.poetry_detection.core import LabeledExcerpt
+from corppa.poetry_detection.passim.get_passim_excerpts import (
+    get_passim_excerpts,
+    save_passim_excerpts,
+)
+
+
+@patch("corppa.poetry_detection.passim.get_passim_excerpts.orjsonl")
+def test_get_passim_exceprts(mock_orjsonl):
+    test_page_data = [
+        # A page with one poem excerpt
+        {
+            "page_id": "page_a",
+            "n_spans": 1,
+            "poem_spans": [
+                {
+                    "ref_id": "poem_a",
+                    "ref_corpus": "r1",
+                    "ref_start": 10,
+                    "ref_end": 11,
+                    "ref_excerpt": "A",
+                    "page_start": 0,
+                    "page_end": 1,
+                    "page_excerpt": "a",
+                },
+            ],
+        },
+        # A page with two poem excerpts
+        {
+            "page_id": "page_b",
+            "n_spans": 2,
+            "poem_spans": [
+                {
+                    "ref_id": "poem_z",
+                    "ref_corpus": "r2",
+                    "ref_start": 11,
+                    "ref_end": 12,
+                    "ref_excerpt": "B",
+                    "page_start": 1,
+                    "page_end": 2,
+                    "page_excerpt": "b",
+                },
+                {
+                    "ref_id": "poem_y",
+                    "ref_corpus": "r2",
+                    "ref_start": 5,
+                    "ref_end": 7,
+                    "ref_excerpt": "bb",
+                    "page_start": 9,
+                    "page_end": 11,
+                    "page_excerpt": "BB",
+                },
+            ],
+        },
+        # A page with no identified poem excerpts
+        {"page_id": "page_c", "n_spans": 0, "poem_spans": []},
+    ]
+    expected_results = [
+        LabeledExcerpt(
+            page_id="page_a",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="a",
+            poem_id="poem_a",
+            ref_corpus="r1",
+            ref_span_start=10,
+            ref_span_end=11,
+            ref_span_text="A",
+            detection_methods={"passim"},
+            identification_methods={"passim"},
+        ),
+        LabeledExcerpt(
+            page_id="page_b",
+            ppa_span_start=1,
+            ppa_span_end=2,
+            ppa_span_text="b",
+            poem_id="poem_z",
+            ref_corpus="r2",
+            ref_span_start=11,
+            ref_span_end=12,
+            ref_span_text="B",
+            detection_methods={"passim"},
+            identification_methods={"passim"},
+        ),
+        LabeledExcerpt(
+            page_id="page_b",
+            ppa_span_start=9,
+            ppa_span_end=11,
+            ppa_span_text="BB",
+            poem_id="poem_y",
+            ref_corpus="r2",
+            ref_span_start=5,
+            ref_span_end=7,
+            ref_span_text="bb",
+            detection_methods={"passim"},
+            identification_methods={"passim"},
+        ),
+    ]
+
+    mock_orjsonl.stream.return_value = iter(test_page_data)
+    results = list(get_passim_excerpts("input"))
+    mock_orjsonl.stream.assert_called_once_with("input")
+
+    # Verify output
+    assert results == expected_results
+
+
+@patch("corppa.poetry_detection.passim.get_passim_excerpts.get_passim_excerpts")
+def test_save_passim_excerpts(mock_get_excerpts, tmpdir):
+    out_csv = tmpdir / "test.csv"
+
+    test_excerpts = [
+        LabeledExcerpt(
+            page_id="a",
+            ppa_span_start=0,
+            ppa_span_end=3,
+            ppa_span_text="abc",
+            detection_methods={"passim"},
+            poem_id="poem",
+            ref_corpus="ref",
+            identification_methods={"passim"},
+        ),
+        LabeledExcerpt(
+            page_id="b",
+            ppa_span_start=0,
+            ppa_span_end=3,
+            ppa_span_text="abc",
+            detection_methods={"passim"},
+            poem_id="poem",
+            ref_corpus="ref",
+            identification_methods={"passim"},
+        ),
+    ]
+
+    mock_get_excerpts.return_value = iter(test_excerpts)
+    save_passim_excerpts("input", out_csv)
+    mock_get_excerpts.assert_called_once_with("input")


### PR DESCRIPTION
ref: #169 #170 #146 

This script adds a bunch of additional functionality to `Excerpt` objects:
- excerpt id creation
- csv format support
- whitespace stripping logic

It also:
- updates the annotation script `processing_adjudication_data.py` to use `Excerpt` objects; and
- updates the passim script `get_passim_excerpts.py` to use `LabeledExcerpt` objects.