### PR TITLE
Add fieldnames method to Excerpt class

### DIFF
--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -3,7 +3,7 @@ Custom data type for poetry excerpts identified with the text of PPA pages.
 """
 
 from copy import deepcopy
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import asdict, dataclass, field, fields, replace
 from typing import Any, Optional
 
 # Table of supported detection methods and their corresponding prefixes
@@ -159,6 +159,12 @@ class Excerpt:
                 else:
                     csv_dict[key] = value
         return csv_dict
+
+    @classmethod
+    def fieldnames(cls) -> list[str]:
+        """Return a list of names for the fields in this class,
+        in order."""
+        return [f.name for f in fields(cls)]
 
     @staticmethod
     def from_dict(d: dict) -> "Excerpt":

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -359,6 +359,20 @@ class TestExcerpt:
         )
         assert excerpt.strip_whitespace() == expected_result
 
+    def test_fieldnames(self):
+        fieldnames = Excerpt.fieldnames()
+        # should match the names of the fields as declared
+        # and in the same order
+        assert fieldnames == [
+            "page_id",
+            "ppa_span_start",
+            "ppa_span_end",
+            "ppa_span_text",
+            "detection_methods",
+            "notes",
+            "excerpt_id",
+        ]
+
 
 class TestLabeledExcerpt:
     def test_init(self):
@@ -507,3 +521,16 @@ class TestLabeledExcerpt:
             error_message = f"Unexpected value type for {field}"
             with pytest.raises(ValueError, match=error_message):
                 LabeledExcerpt.from_dict(bad_dict)
+
+    def test_fieldnames(self):
+        fieldnames = LabeledExcerpt.fieldnames()
+        # should inherit from Excerpt but include
+        # additional fields
+        assert fieldnames == Excerpt.fieldnames() + [
+            "poem_id",
+            "ref_corpus",
+            "ref_span_start",
+            "ref_span_end",
+            "ref_span_text",
+            "identification_methods",
+        ]


### PR DESCRIPTION
@laurejt I cherry-picked the excerpt fieldnames method from my #150 PR so I can use it in the merge script without pulling in all the other changes. 