### PR TITLE
Excerpt improvements

### DIFF
--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -95,7 +95,11 @@ def field_real_type(field_type) -> type:
         return origin
     # if Optional or Union, return the first non-none type
     ftypes = get_args(field_type)
-    return [arg for arg in ftypes if arg != types.NoneType][0]
+    if ftypes:
+        return [arg for arg in ftypes if arg != types.NoneType][0]
+
+    # if we get here, this is an input we can't handle
+    raise ValueError(f"Cannot determine real type for '{field_type}'")
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -2,6 +2,7 @@
 Custom data type for poetry excerpts identified with the text of PPA pages.
 """
 
+import functools
 import types
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields, replace
@@ -184,12 +185,14 @@ class Excerpt:
         return csv_dict
 
     @classmethod
+    @functools.cache
     def fieldnames(cls) -> list[str]:
         """Return a list of names for the fields in this class,
         in order."""
         return [f.name for f in fields(cls)]
 
     @classmethod
+    @functools.cache
     def field_types(cls) -> dict[str, Any]:
         """Return a dictionary of field names and corresponding types
         for this class."""

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -104,7 +104,7 @@ def field_real_type(field_type) -> type:
 
 
 #: character to use when converting sets to and from delimited string
-MULTIVAL_DELIMITER = ";"
+MULTIVAL_DELIMITER = "; "
 
 
 def input_to_set(input_val: list | str | set) -> set:

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -103,6 +103,10 @@ def field_real_type(field_type) -> type:
     raise TypeError(f"Cannot determine real type for '{field_type}'")
 
 
+#: character to use when converting sets to and from delimited string
+MULTIVAL_DELIMITER = ";"
+
+
 def input_to_set(input_val: list | str | set) -> set:
     """Convert supported inputs to set; intended for convenience
     when initializing :attr:`Excerpt.detection_methods` and
@@ -113,7 +117,7 @@ def input_to_set(input_val: list | str | set) -> set:
         case list():  # format used by to_json
             return set(input_val)
         case str():  # format used by to_csv
-            return set(input_val.split(", "))
+            return set(input_val.split(MULTIVAL_DELIMITER))
         case set():
             return set(input_val)
         case _:
@@ -194,9 +198,10 @@ class Excerpt:
         csv_dict: dict[str, int | str] = {}
         for key, value in asdict(self).items():
             if value is not None:
-                # Convert sets to comma-separated lists
+                # Convert sets to delimited string
                 if type(value) is set:
-                    csv_dict[key] = ", ".join(value)
+                    # to guarantee deterministic order, sort before joining
+                    csv_dict[key] = MULTIVAL_DELIMITER.join(sorted(value))
                 else:
                     csv_dict[key] = value
         return csv_dict

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -6,7 +6,7 @@ import functools
 import types
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields, replace
-from typing import Any, Optional, TypeAliasType, Union, get_args, get_origin
+from typing import Any, Optional, get_args, get_origin
 
 # Table of supported detection methods and their corresponding prefixes
 DETECTION_METHODS = {

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -279,3 +279,12 @@ class LabeledExcerpt(Excerpt):
             raise ValueError(
                 f"Reference span's start index {self.ref_span_start} must be less than its end index {self.ref_span_end}"
             )
+
+    @classmethod
+    def from_excerpt(cls, ex: Excerpt, **kwargs: dict) -> "LabeledExcerpt":
+        """Create a :class:`LabeledExcerpt` using an :class:`Excerpt` as a
+        starting point and supplying data for additional fields."""
+        excerpt_info = asdict(ex)
+        excerpt_info.update(kwargs)
+        excerpt_info.pop("excerpt_id")
+        return cls(**excerpt_info)

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -222,7 +222,7 @@ class Excerpt:
     def from_dict(cls, d: dict) -> "Excerpt":
         """
         Constructs a new Excerpt from a dictionary of the form produced by `to_dict`
-        or `to_json`.
+        or `to_csv`.
         """
         input_args = deepcopy(d)
         # Remove excerpt_id if present

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -123,7 +123,7 @@ def input_to_set(input_val: list | str | set) -> set:
         case str():  # format used by to_csv
             return set(input_val.split(MULTIVAL_DELIMITER))
         case set():
-            return set(input_val)
+            return input_val
         case _:
             raise ValueError(f"Unexpected value type '{type(input_val).__name__}'")
 

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -187,7 +187,9 @@ class Excerpt:
             else:
                 input_args["detection_methods"] = {detection_methods}
         else:
-            raise ValueError("Unexpected value type for detection_methods")
+            raise ValueError(
+                f"Unexpected value type '{type(detection_methods).__name__}' for detection_methods"
+            )
         return Excerpt(**input_args)
 
     def strip_whitespace(self) -> "Excerpt":
@@ -255,5 +257,8 @@ class LabeledExcerpt(Excerpt):
                 ## `to_csv` format
                 input_args[fieldname] = set(value.split(", "))
             else:
-                raise ValueError(f"Unexpected value type for {fieldname}")
+                raise ValueError(
+                    f"Unexpected value type '{type(value).__name__}' for {fieldname}"
+                )
+
         return LabeledExcerpt(**input_args)

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -207,14 +207,12 @@ class Excerpt:
         return csv_dict
 
     @classmethod
-    @functools.cache
     def fieldnames(cls) -> list[str]:
         """Return a list of names for the fields in this class,
         in order."""
         return [f.name for f in fields(cls)]
 
     @classmethod
-    @functools.cache
     def field_types(cls) -> dict[str, Any]:
         """Return a dictionary of field names and corresponding types
         for this class."""

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -82,9 +82,13 @@ class Span:
 
 
 def field_real_type(field_type) -> type:
-    """Return the base type for a dataclass field type annotation.
-    For unions or optional values, returns the first non-None type; for type
-    aliases, returns the original type.
+    """Return the real type for a dataclass field type annotation.
+    For unions or optional values (e.g. `Optional[int]`), returns the first
+    non-None type; for type aliases (e.g. `set[str]`, returns the original type
+    that was used to create the alias. For example:
+        - int -> int
+        - Optional[int] -> int
+        - set[str] -> set
     """
     # if it's a regular type, return unchanged
     if isinstance(field_type, type):

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -584,6 +584,6 @@ def test_field_real_type():
     # optional (= union of type and NoneType)
     assert field_real_type(Optional[int]) == int
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         # method doesn't support anything that isn't a type or type alias
         field_real_type("text content")

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -373,6 +373,18 @@ class TestExcerpt:
             "excerpt_id",
         ]
 
+    def test_field_types(self):
+        field_types = Excerpt.field_types()
+        assert field_types == {
+            "page_id": str,
+            "ppa_span_start": int,
+            "ppa_span_end": int,
+            "ppa_span_text": str,
+            "detection_methods": set,
+            "notes": str,
+            "excerpt_id": str,
+        }
+
 
 class TestLabeledExcerpt:
     def test_init(self):
@@ -534,3 +546,19 @@ class TestLabeledExcerpt:
             "ref_span_text",
             "identification_methods",
         ]
+
+    def test_field_types(self):
+        field_types = LabeledExcerpt.field_types()
+        expected_types = Excerpt.field_types()
+        expected_types.update(
+            {
+                "poem_id": str,
+                "ref_corpus": str,
+                "ref_span_start": int,
+                "ref_span_end": int,
+                "ref_span_text": str,
+                "identification_methods": set,
+            }
+        )
+
+        assert field_types == expected_types

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -266,7 +266,9 @@ class TestExcerpt:
         # with multiple values for set field
         excerpt = replace(excerpt, detection_methods={"manual", "passim"})
         expected_result["excerpt_id"] = "c@0:1"
-        expected_result["detection_methods"] = "manual;passim"
+        expected_result["detection_methods"] = MULTIVAL_DELIMITER.join(
+            ["manual", "passim"]
+        )
         assert excerpt.to_csv() == expected_result
 
     def test_from_dict(self):

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -575,6 +575,41 @@ class TestLabeledExcerpt:
 
         assert field_types == expected_types
 
+    def test_from_excerpt(self):
+        excerpt = Excerpt(
+            page_id="page_id",
+            ppa_span_start=0,
+            ppa_span_end=1,
+            ppa_span_text="page_text",
+            detection_methods={"manual"},
+        )
+        # initialize with all required fields
+        labeled_ex = LabeledExcerpt.from_excerpt(
+            excerpt,
+            poem_id="Z1234",
+            ref_corpus="test-corpus",
+            identification_methods={"manual"},
+        )
+        # spot check resulting object
+        assert labeled_ex.page_id == excerpt.page_id
+        assert labeled_ex.excerpt_id == excerpt.excerpt_id
+        assert labeled_ex.poem_id == "Z1234"
+        assert labeled_ex.ref_corpus == "test-corpus"
+
+        # should be able to override fields
+        labeled_ex = LabeledExcerpt.from_excerpt(
+            excerpt,
+            ppa_span_end=10,
+            poem_id="Z1234",
+            ref_corpus="test-corpus",
+            identification_methods={"manual"},
+        )
+        assert labeled_ex.ppa_span_end == 10
+
+        # results in init error without required fields
+        with pytest.raises(TypeError, match="missing 3 required"):
+            LabeledExcerpt.from_excerpt(excerpt)
+
 
 def test_field_real_type():
     # regular type

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -249,16 +249,18 @@ class TestExcerpt:
             "detection_methods": "manual",
             "excerpt_id": "m@0:1",
         }
-
-        result = excerpt.to_csv()
-        assert result == expected_result
+        assert excerpt.to_csv() == expected_result
 
         # With optional fields
         excerpt = replace(excerpt, notes="notes")
         expected_result["notes"] = "notes"
+        assert excerpt.to_csv() == expected_result
 
-        result = excerpt.to_csv()
-        assert result == expected_result
+        # with multiple values for set field
+        excerpt = replace(excerpt, detection_methods={"manual", "passim"})
+        expected_result["excerpt_id"] = "c@0:1"
+        expected_result["detection_methods"] = "manual;passim"
+        assert excerpt.to_csv() == expected_result
 
     def test_from_dict(self):
         # JSONL-friendly dict

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -4,7 +4,14 @@ from unittest.mock import patch
 
 import pytest
 
-from corppa.poetry_detection.core import Excerpt, LabeledExcerpt, Span, field_real_type
+from corppa.poetry_detection.core import (
+    MULTIVAL_DELIMITER,
+    Excerpt,
+    LabeledExcerpt,
+    Span,
+    field_real_type,
+    input_to_set,
+)
 
 
 class TestSpan:
@@ -624,3 +631,17 @@ def test_field_real_type():
     with pytest.raises(TypeError):
         # method doesn't support anything that isn't a type or type alias
         field_real_type("text content")
+
+
+def test_input_to_set():
+    # string, single value
+    assert input_to_set("a") == {"a"}
+    # delimited string
+    assert input_to_set(MULTIVAL_DELIMITER.join(["a", "b"])) == {"a", "b"}
+    # list
+    assert input_to_set(["a", "b", "c"]) == {"a", "b", "c"}
+    # set
+    assert input_to_set({"a", "b", "c"}) == {"a", "b", "c"}
+    # unsupported input
+    with pytest.raises(ValueError, match="Unexpected value type 'int'"):
+        input_to_set(1)

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -382,6 +382,21 @@ class TestExcerpt:
             "excerpt_id": str,
         }
 
+    @patch("corppa.poetry_detection.core.field_real_type")
+    def test_field_types_cached(self, mock_field_real_type):
+        # clear the cache so we can confirm it works as expected
+        Excerpt.field_types.cache_clear()
+        field_info = Excerpt.field_types()
+        # field type method should be called once for each field
+        assert mock_field_real_type.call_count == len(field_info)
+
+        # should be cached and not called again; call count should stay the same
+        field_info = Excerpt.field_types()
+        assert mock_field_real_type.call_count == len(field_info)
+
+        # reclear the cache to remove mock values from cached result
+        Excerpt.field_types.cache_clear()
+
 
 class TestLabeledExcerpt:
     def test_init(self):
@@ -570,5 +585,5 @@ def test_field_real_type():
     assert field_real_type(Optional[int]) == int
 
     with pytest.raises(ValueError):
-        # we don't support anything that isn't a type or type alias
+        # method doesn't support anything that isn't a type or type alias
         field_real_type("text content")

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -1,13 +1,10 @@
 from dataclasses import replace
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
 
-from corppa.poetry_detection.core import (
-    Excerpt,
-    LabeledExcerpt,
-    Span,
-)
+from corppa.poetry_detection.core import Excerpt, LabeledExcerpt, Span, field_real_type
 
 
 class TestSpan:
@@ -562,3 +559,16 @@ class TestLabeledExcerpt:
         )
 
         assert field_types == expected_types
+
+
+def test_field_real_type():
+    # regular type
+    assert field_real_type(str) == str
+    # type annotation / alas
+    assert field_real_type(set[str]) == set
+    # optional (= union of type and NoneType)
+    assert field_real_type(Optional[int]) == int
+
+    with pytest.raises(ValueError):
+        # we don't support anything that isn't a type or type alias
+        field_real_type("text content")

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -286,7 +286,7 @@ class TestExcerpt:
 
         # Error if detection_methods field has bad type
         bad_dict = csv_dict | {"detection_methods": 0}
-        error_message = "Unexpected value type for detection_methods"
+        error_message = "Unexpected value type 'int' for detection_methods"
         with pytest.raises(ValueError, match=error_message):
             Excerpt.from_dict(bad_dict)
 
@@ -518,7 +518,7 @@ class TestLabeledExcerpt:
         # Error if detection or identification methods fields have bad type
         for field in ["detection_methods", "identification_methods"]:
             bad_dict = csv_dict | {field: 0}
-            error_message = f"Unexpected value type for {field}"
+            error_message = f"Unexpected value type 'int' for {field}"
             with pytest.raises(ValueError, match=error_message):
                 LabeledExcerpt.from_dict(bad_dict)
 

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -391,21 +391,6 @@ class TestExcerpt:
             "excerpt_id": str,
         }
 
-    @patch("corppa.poetry_detection.core.field_real_type")
-    def test_field_types_cached(self, mock_field_real_type):
-        # clear the cache so we can confirm it works as expected
-        Excerpt.field_types.cache_clear()
-        field_info = Excerpt.field_types()
-        # field type method should be called once for each field
-        assert mock_field_real_type.call_count == len(field_info)
-
-        # should be cached and not called again; call count should stay the same
-        field_info = Excerpt.field_types()
-        assert mock_field_real_type.call_count == len(field_info)
-
-        # reclear the cache to remove mock values from cached result
-        Excerpt.field_types.cache_clear()
-
 
 class TestLabeledExcerpt:
     def test_init(self):
@@ -583,6 +568,10 @@ class TestLabeledExcerpt:
         )
 
         assert field_types == expected_types
+
+        # field types for subclass should not be the same
+        # (caching the method breaks this)
+        assert LabeledExcerpt.field_types() != Excerpt.field_types()
 
     def test_from_excerpt(self):
         excerpt = Excerpt(


### PR DESCRIPTION
This PR includes updates and improvements to Excerpt objects to support work on the merge script #156 and includes some changes pulled from the PR for that script #174 

changes include:
- new method to return a dictionary of field names and field base types 
  - supporting method to get actual type from field type annotation
  - ~add caching to fieldnames and field_types class methods~ (removed: causes problems with inheritance)
- consolidate `from_dict` method 
   - move input to set conversion to a method
   - rewrite as a single inherited method
   - add type details to exception message when methods values are passed in as an unsupported type
 - use a define delimiter character when converting sets to and from delimited string
 - add and test new `from_excerpt` method