### PR TITLE
Revise chadwyck-healey metadata to output id instead of filename

### DIFF
--- a/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
+++ b/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
@@ -299,7 +299,7 @@ class TMLPoetryParser:
 
     # Field names for output metadata
     metadata_fields = [
-        "filename",
+        "id",
         "author_lastname",
         "author_firstname",
         "author_birth",
@@ -692,7 +692,7 @@ class TMLPoetryParser:
 
             # extract metadata from the header section
             metadata = self.extract_metadata(soup)
-            metadata["filename"] = file_path.name
+            metadata["id"] = file_path.stem
 
             # in metadata-only mode, bail out before text extraction logic, returning None for poetry_text
             if self.metadata_only:


### PR DESCRIPTION
For use with the poem dataset we need chadwyck healey ids rather than filenames. My preference is to only include the id instead of the filename since we can (generally) determine filename from id. Is there any case that we care about where this is a problem? 