### PR TITLE
Chadwyck-Healey: Add filtering logic & fix for dods as dobs

### DIFF
--- a/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
+++ b/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
@@ -826,8 +826,8 @@ class TMLPoetryParser:
             writer = csv.DictWriter(csvfile, fieldnames=self.metadata_fields)
             writer.writeheader()
 
-            processed = False
             for i, file_path in enumerate(file_progress):
+                processed = False
                 if num_files and i == num_files:
                     # Exit early if limit reached
                     break

--- a/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
+++ b/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
@@ -292,14 +292,15 @@ def replace_entities(text: str, entity_map: dict[str, str] = CUSTOM_ENTITY_MAP) 
     return text
 
 
-def ppa_relevant(poem_meta: dict[str, str]) -> bool:
+def filter_post_1928(poem_meta: dict[str, str]) -> bool:
     """
-    Determine if a poem is relevant to the PPA which is currently limited to works
-    written before 1929. If a poem's metadata indicates that a poem is too recent,
-    it will be excluded form teh resulting working set.
+    Determine if a poem was written in 1929 or later (i.e., post-1928) based on its
+    metadata (as possible). Only pre-1929 works are relevant to the PPA. If a poem
+    was written after 1928, then it should be excluded from the filtered working set.
 
-    Returns ``True`` if the poem's metadata should be included, and ``False`` if
-    the poem should be excluded.
+    Returns
+    - ``False`` if a poem was written post-1928
+    - ``True`` otherwise (i.e., written pre-1929 or a year cannot be determined)
     """
     # 1. Attempt to filter by period tag:
     #    Pass: poems from periods before the 20th c. (all other tags)
@@ -756,7 +757,7 @@ class TMLPoetryParser:
             metadata["id"] = file_path.stem
 
             # if filtering is set, return null objects if metadata fails filter
-            if self.filter_results and not ppa_relevant(metadata):
+            if self.filter_results and not filter_post_1928(metadata):
                 ## Treat empty dict as "skip" signal
                 return [], None
 

--- a/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
+++ b/src/corppa/poetry_detection/chadwyck_healey/tml_parser.py
@@ -292,10 +292,12 @@ def replace_entities(text: str, entity_map: dict[str, str] = CUSTOM_ENTITY_MAP) 
     return text
 
 
-def passes_filter(poem_meta: dict[str, str]) -> bool:
+def ppa_relevant(poem_meta: dict[str, str]) -> bool:
     """
-    Determine if a poem should be included in results based on its metadata.
-    Works too recent (written ~1929 or later) are excluded from the working set.
+    Determine if a poem is relevant to the PPA which is currently limited to works
+    written before 1929. If a poem's metadata indicates that a poem is too recent,
+    it will be excluded form teh resulting working set.
+
     Returns ``True`` if the poem's metadata should be included, and ``False`` if
     the poem should be excluded.
     """
@@ -754,7 +756,7 @@ class TMLPoetryParser:
             metadata["id"] = file_path.stem
 
             # if filtering is set, return null objects if metadata fails filter
-            if self.filter_results and not passes_filter(metadata):
+            if self.filter_results and not ppa_relevant(metadata):
                 ## Treat empty dict as "skip" signal
                 return [], None
 
@@ -817,7 +819,12 @@ class TMLPoetryParser:
             bar_format = (
                 "{desc}: {n:,} files processed | elapsed: {elapsed}, {rate_fmt}"
             )
-            file_progress = tqdm(tml_gen, desc=desc, disable=not self.show_progress)
+            file_progress = tqdm(
+                tml_gen,
+                desc=desc,
+                bar_format=bar_format,
+                disable=not self.show_progress,
+            )
 
         n_attempted = 0
         n_processed = 0

--- a/test/test_poetry_detection/test_chadwyck_healey/test_tml_parser.py
+++ b/test/test_poetry_detection/test_chadwyck_healey/test_tml_parser.py
@@ -2,7 +2,7 @@ import pytest
 
 from corppa.poetry_detection.chadwyck_healey.tml_parser import (
     determine_encoding,
-    passes_filter,
+    ppa_relevant,
     replace_entities,
 )
 
@@ -55,7 +55,7 @@ def test_replace_entities():
     assert replace_entities(text) == expected_result
 
 
-def test_passes_filter():
+def test_ppa_relevant():
     # Basic required poem metadata form
     basic_meta = {
         k: "" for k in ["period", "author_birth", "author_death", "edition_text"]
@@ -69,10 +69,10 @@ def test_passes_filter():
     }:
         poem_meta = basic_meta | {"period": period}
         # Basic case
-        assert passes_filter(poem_meta)
+        assert ppa_relevant(poem_meta)
         # Passes regardless of date(s) in author_birth and edition_text fields
-        assert passes_filter(poem_meta | {"author_birth": "2000"})
-        assert passes_filter(poem_meta | {"edition_text": "2000"})
+        assert ppa_relevant(poem_meta | {"author_birth": "2000"})
+        assert ppa_relevant(poem_meta | {"edition_text": "2000"})
 
     # 2. Author death year
     for period in ["", "Twentieth-Century 1900-1999"]:
@@ -80,27 +80,27 @@ def test_passes_filter():
         # Passes if author_death is before 1929
         for year in ["1901", "1928", "BC", "BC50"]:
             dod_meta = poem_meta | {"author_death": year}
-            assert passes_filter(dod_meta)
+            assert ppa_relevant(dod_meta)
             # Passes regardless of date(s) in author_birth and edition_text fields
-            assert passes_filter(dod_meta | {"author_birth": "2000"})
-            assert passes_filter(dod_meta | {"edition_text": "2000"})
+            assert ppa_relevant(dod_meta | {"author_birth": "2000"})
+            assert ppa_relevant(dod_meta | {"edition_text": "2000"})
 
     # 3. Check author birth year
     for period in ["", "Twentieth-Century 1900-1999"]:
         poem_meta = basic_meta | {"period": period}
         # Passes if author_birth is before 1915
         for year in {"1901", "B.C.40", "BC120", "cent.15th"}:
-            assert passes_filter(poem_meta | {"author_birth": year})
+            assert ppa_relevant(poem_meta | {"author_birth": year})
             ## Passes regardless of date(s) in edition_fields
-            assert passes_filter(
+            assert ppa_relevant(
                 poem_meta | {"author_birth": year, "edition_text": "2000"}
             )
 
         # Fails if author_birth is 1915 or later
         for year in {"1915", "1916", "2000"}:
-            assert not passes_filter(poem_meta | {"author_birth": year})
+            assert not ppa_relevant(poem_meta | {"author_birth": year})
             ## Fails regardless of date(s) in edition_fields
-            assert not passes_filter(
+            assert not ppa_relevant(
                 poem_meta | {"author_birth": year, "edition_text": "1900"}
             )
 
@@ -111,13 +111,13 @@ def test_passes_filter():
         poem_meta = basic_meta | {"period": period}
         # Passes if edition contains a date before 1929
         for title in pass_titles:
-            assert passes_filter(poem_meta | {"edition_text": title})
+            assert ppa_relevant(poem_meta | {"edition_text": title})
         # Fails if editions contains date that are >= 1929
         for title in fail_titles:
-            assert not passes_filter(poem_meta | {"edition_text": title})
+            assert not ppa_relevant(poem_meta | {"edition_text": title})
 
     # 4. Catch-all
     ## 20th century poems without additional metadata fail
-    assert not passes_filter(basic_meta | {"period": "Twentieth-Century 1900-1999"})
+    assert not ppa_relevant(basic_meta | {"period": "Twentieth-Century 1900-1999"})
     ## poems without tags or any other additional metadata pass
-    assert passes_filter(basic_meta)
+    assert ppa_relevant(basic_meta)

--- a/test/test_poetry_detection/test_chadwyck_healey/test_tml_parser.py
+++ b/test/test_poetry_detection/test_chadwyck_healey/test_tml_parser.py
@@ -2,6 +2,7 @@ import pytest
 
 from corppa.poetry_detection.chadwyck_healey.tml_parser import (
     determine_encoding,
+    passes_filter,
     replace_entities,
 )
 
@@ -52,3 +53,71 @@ def test_replace_entities():
     text = "&GREs;&grP;&grW;&GRST;"
     expected_result = "ἘΠΩς"
     assert replace_entities(text) == expected_result
+
+
+def test_passes_filter():
+    # Basic required poem metadata form
+    basic_meta = {
+        k: "" for k in ["period", "author_birth", "author_death", "edition_text"]
+    }
+
+    # 1. Poems with non-20th century period tags pass
+    for period in {
+        "Fifteenth-Century Poetry",
+        "Middle English Poetry 1100-1400",
+        "foo",
+    }:
+        poem_meta = basic_meta | {"period": period}
+        # Basic case
+        assert passes_filter(poem_meta)
+        # Passes regardless of date(s) in author_birth and edition_text fields
+        assert passes_filter(poem_meta | {"author_birth": "2000"})
+        assert passes_filter(poem_meta | {"edition_text": "2000"})
+
+    # 2. Author death year
+    for period in ["", "Twentieth-Century 1900-1999"]:
+        poem_meta = basic_meta | {"period": period}
+        # Passes if author_death is before 1929
+        for year in ["1901", "1928", "BC", "BC50"]:
+            dod_meta = poem_meta | {"author_death": year}
+            assert passes_filter(dod_meta)
+            # Passes regardless of date(s) in author_birth and edition_text fields
+            assert passes_filter(dod_meta | {"author_birth": "2000"})
+            assert passes_filter(dod_meta | {"edition_text": "2000"})
+
+    # 3. Check author birth year
+    for period in ["", "Twentieth-Century 1900-1999"]:
+        poem_meta = basic_meta | {"period": period}
+        # Passes if author_birth is before 1915
+        for year in {"1901", "B.C.40", "BC120", "cent.15th"}:
+            assert passes_filter(poem_meta | {"author_birth": year})
+            ## Passes regardless of date(s) in edition_fields
+            assert passes_filter(
+                poem_meta | {"author_birth": year, "edition_text": "2000"}
+            )
+
+        # Fails if author_birth is 1915 or later
+        for year in {"1915", "1916", "2000"}:
+            assert not passes_filter(poem_meta | {"author_birth": year})
+            ## Fails regardless of date(s) in edition_fields
+            assert not passes_filter(
+                poem_meta | {"author_birth": year, "edition_text": "1900"}
+            )
+
+    # 3. Check edition title
+    pass_titles = ["1915", "title [1928]", "poems 1901-1938 [1999]"]
+    fail_titles = ["2010", "title (1929)", "poems 1940-60 (1980)"]
+    for period in ["", "Twentieth-Century 1900-1999"]:
+        poem_meta = basic_meta | {"period": period}
+        # Passes if edition contains a date before 1929
+        for title in pass_titles:
+            assert passes_filter(poem_meta | {"edition_text": title})
+        # Fails if editions contains date that are >= 1929
+        for title in fail_titles:
+            assert not passes_filter(poem_meta | {"edition_text": title})
+
+    # 4. Catch-all
+    ## 20th century poems without additional metadata fail
+    assert not passes_filter(basic_meta | {"period": "Twentieth-Century 1900-1999"})
+    ## poems without tags or any other additional metadata pass
+    assert passes_filter(basic_meta)


### PR DESCRIPTION
ref: #181 

Primarily, this PR incorporates (optionally) the filtering logic into the script. Additionally, it makes a metadata extraction correction where author death dates were being saved as author birth dates.