### PR TITLE
Merge labeled and unlabeled excerpts

### DIFF
--- a/docs/source/code-docs.rst
+++ b/docs/source/code-docs.rst
@@ -1,24 +1,36 @@
 Code Documentation
-==================
+##################
 
 .. toctree::
    :maxdepth: 2
 
 OCR
-----------
+===
 .. automodule:: corppa.ocr.gvision_ocr
   :members:
 
 Utils
------
+=====
 
 Filter Utility
-^^^^^^^^^^^^^^
+--------------
 .. automodule:: corppa.utils.filter
   :members:
 
 Path Utilities
-^^^^^^^^^^^^^^
+--------------
 .. automodule:: corppa.utils.path_utils
   :members:
 
+
+Poetry Detection
+================
+
+Scripts
+-------
+
+Merge excerpts 
+^^^^^^^^^^^^^^
+
+.. automodule:: corppa.poetry_detection.merge_excerpts
+.. Note: not including members for method docs, only top-level script usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ test = [
 corppa-filter = "corppa.utils.filter:main"
 corppa-ocr = "corppa.ocr.gvision_ocr:main"
 collate-txt = "corppa.ocr.collate_txt:main"
+merge-excerpts = "corppa.poetry_detection.merge_excerpts:main"
 
 [tool.hatch.version]
 path = "src/corppa/__init__.py"

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -242,8 +242,6 @@ def main():
     # load files and combine into a single excerpt dataframe
     for input_file in args.input_files:
         try:
-            # NOTE: very important to standardize input so that
-            # extraneous columns do not prevent duplicate excerpts from merging
             input_dfs.append(load_excerpts_df(input_file))
         except ValueError as err:
             # if any input file does not have minimum required fields, bail out
@@ -257,7 +255,7 @@ def main():
     excerpts = standardize_dataframe(pl.concat(input_dfs, how="diagonal"))
     # get initial totals before any uniquifying or merging
     total_excerpts = excerpts.height
-    # use unique to drop exact duplicates (passim results include exact dupes)
+    # use unique to drop exact duplicates
     excerpts = excerpts.unique()
     initial_labeled_excerpts = excerpts.filter(pl.col("poem_id").is_not_null()).height
     # output summary information about input data

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -13,7 +13,7 @@ the output will likely be a mix of labeled and unlabeled excerpts.
 Merging logic is as follows:
 
 - Excerpts are grouped on the combination of page id and excerpt id,
-  and then merged if all refence fields match exactly, or where
+  and then merged if all reference fields match exactly, or where
   reference fields are present in one excerpt and unset in the other.
     - If the same excerpt has different labels (different `poem_id` values), both
       labeled excerpts will be included in the output

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -56,7 +56,7 @@ from corppa.poetry_detection.polars_utils import load_excerpts_df, standardize_d
 def combine_duplicate_methods_notes(repeats_df: pl.DataFrame) -> pl.DataFrame:
     """
     Takes a dataframe of repeated excerpts with duplicate information,
-    and updateds all rows with combined set of unique
+    and updates all rows with the combined set of unique
     detection_methods, identification_methods, and notes. Returns the
     updated dataframe with the combined fields.
 

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-This script merges detected poems excerpts (i.e. :class:~`corppa.poetry_detection.core.Excerpt`)
-with identified poem excerpts (i.e. :class:~`corppa.poetry_detection.core.LabeledExcerpt`);
+This script merges detected poems excerpts (:class:`~corppa.poetry_detection.core.Excerpt`)
+with identified poem excerpts (:class:`~corppa.poetry_detection.core.LabeledExcerpt`);
 it also handles merging duplicate poem identifications in simple cases.
 
 It takes two or more input files of excerpt or labeled excerpt data in CSV format,
@@ -11,9 +11,8 @@ This means that in most cases, the output will likely be a mix of labeled
 and unlabeled excerpts.
 
 Merging logic is as follows:
-- Excerpts are grouped on the combination of page id and excerpt id and then
-  merged if all reference fields match exactly, or where reference fields are
-  present in one excerpt and null in the other.
+
+- Excerpts are grouped on the combination of page id and excerpt id and then merged if all reference fields match exactly, or where reference fields are present in one excerpt and null in the other.
     - If the same excerpt has different labels (different `poem_id` values), both
       labeled excerpts will be included in the output
     - If the same excerpt has duplicate labels (i.e., the same `poem_id` from two
@@ -23,7 +22,12 @@ Merging logic is as follows:
 - When merging excerpts where both records have notes, the notes content
   will be combined.
 
+Example usage:
+
+``./src/corppa/poetry_detection/merge_excerpts.py adjudication_excerpts.csv labeled_excerpts.csv -o merged_excerpts.csv``
+
 Limitations:
+
 - Merging based on poem_id does not compare or consolidate reference span indices
   and text fields; supporting multiple identification methods that output
   span information will require revision

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -42,7 +42,7 @@ def fix_data_types(df):
         # For list (set) types, split strings on multival delimiter to convert to list
         if ctype is pl.List:
             # if excerpt content is loaded from csv, it will have an inferred
-            # type of string; split string content on our deliminter and
+            # type of string; split string content on our delimiter and
             # convert to list of string
             if df.schema[c] == pl.String:
                 df = df.with_columns(pl.col(c).str.split(MULTIVAL_DELIMITER))

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -41,9 +41,14 @@ def fix_data_types(df):
     for c, ctype in df_types.items():
         # For list (set) types, split strings on multival delimiter to convert to list
         if ctype is pl.List:
-            # only split if column is currently a string
+            # if excerpt content is loaded from csv, it will have an inferred
+            # type of string; split string content on our deliminter and
+            # convert to list of string
             if df.schema[c] == pl.String:
                 df = df.with_columns(pl.col(c).str.split(MULTIVAL_DELIMITER))
+            # if a list column is loaded with no data (i.e., identification_methods
+            # is present but has no content), it will have an inferred type of null
+            # convert to list of string
             elif df.schema[c] == pl.Null:
                 df = df.with_columns(pl.col(c).cast(pl.List(pl.String)))
         # For any other field type, cast the column to the expected type

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -44,6 +44,8 @@ def fix_data_types(df):
             # only split if column is currently a string
             if df.schema[c] == pl.String:
                 df = df.with_columns(pl.col(c).str.split(MULTIVAL_DELIMITER))
+            elif df.schema[c] == pl.Null:
+                df = df.with_columns(pl.col(c).cast(pl.List(pl.String)))
         # For any other field type, cast the column to the expected type
         elif ctype is not None:
             df = df.with_columns(pl.col(c).cast(ctype))

--- a/test/test_poetry_detection/test_merge_excerpts.py
+++ b/test/test_poetry_detection/test_merge_excerpts.py
@@ -410,7 +410,7 @@ def test_main_successful(capsys, tmp_path):
         captured = capsys.readouterr()
 
     # summary output
-    assert "Loaded 4 excerpts from 2 files (2 labeled)" in captured.out
+    assert "Loaded 4 excerpts from 2 files (4 unique; 2 labeled)" in captured.out
     assert "2 excerpts after merging; 1 labeled excerpts" in captured.out
 
     with output_file.open(encoding="utf-8") as merged_csv:

--- a/test/test_poetry_detection/test_merge_excerpts.py
+++ b/test/test_poetry_detection/test_merge_excerpts.py
@@ -82,7 +82,7 @@ def test_merge_excerpts_1ex_2labels():
     merged = merge_excerpts(df)
     # expect two rows with two different labels
     assert len(merged) == 2
-    # original orderis NOT preserved due to grouping and sorting
+    # original order is NOT preserved due to grouping and sorting
     # results should exactly match the labeled excerpts since all other fields are same
     assert LabeledExcerpt.from_dict(merged.row(0, named=True)) == excerpt1_label2
     assert LabeledExcerpt.from_dict(merged.row(1, named=True)) == excerpt1_label1

--- a/test/test_poetry_detection/test_merge_excerpts.py
+++ b/test/test_poetry_detection/test_merge_excerpts.py
@@ -361,8 +361,8 @@ def test_main_successful(capsys, tmp_path):
         captured = capsys.readouterr()
 
     # summary output
-    assert "Loaded 4 excerpts (2 labeled) from 2 files" in captured.out
-    assert "2 total excerpts after merging; 1 labeled excerpts" in captured.out
+    assert "Loaded 4 excerpts from 2 files (2 labeled)" in captured.out
+    assert "2 excerpts after merging; 1 labeled excerpts" in captured.out
 
     with output_file.open(encoding="utf-8") as merged_csv:
         csv_reader = csv.DictReader(merged_csv)

--- a/test/test_poetry_detection/test_polars_utils.py
+++ b/test/test_poetry_detection/test_polars_utils.py
@@ -106,6 +106,20 @@ def test_fix_datatypes():
     assert detect_methods_parsed == [["manual"], ["manual", "passim"], None]
 
 
+def test_fix_datatypes_null_to_list():
+    df = pl.DataFrame(
+        {
+            "poem_id": ["a1", "a2", "a3"],
+            "ppa_span_start": ["1", "2", "3"],
+            "detection_methods": [None, None, None],
+        }
+    )
+    # if no values are set in a list field, type is pl.Null
+    fixed_df = fix_data_types(df)
+    # type should be set to list of string
+    assert fixed_df.schema["detection_methods"] == pl.List(pl.String)
+
+
 def test_load_excerpts_df(tmp_path):
     datafile = tmp_path / "excerpts.csv"
     # valid excerpt data

--- a/test/test_poetry_detection/test_polars_utils.py
+++ b/test/test_poetry_detection/test_polars_utils.py
@@ -109,15 +109,15 @@ def test_fix_datatypes():
 def test_fix_datatypes_null_to_list():
     df = pl.DataFrame(
         {
-            "poem_id": ["a1", "a2", "a3"],
-            "ppa_span_start": ["1", "2", "3"],
-            "detection_methods": [None, None, None],
+            "poem_id": ["a", "b"],
+            "ppa_span_start": ["1", "2"],
+            "identification_methods": [None, None],
         }
     )
     # if no values are set in a list field, type is pl.Null
     fixed_df = fix_data_types(df)
     # type should be set to list of string
-    assert fixed_df.schema["detection_methods"] == pl.List(pl.String)
+    assert fixed_df.schema["identification_methods"] == pl.List(pl.String)
 
 
 def test_load_excerpts_df(tmp_path):


### PR DESCRIPTION
Modifies merge script to handle more cases and simplify the code; addresses #189 

Revised to load all input files into a single dataframe, and then merge based on groupings of page id + excerpt id.  I was able to completely remove the old method that was doing the joins, and updated the existing tests to confirm the we get the expected results from the revised method.  

Here's the summary output from running it on all the adjucation data I have locally:
```console
 ❯ ./src/corppa/poetry_detection/merge_excerpts.py finish-line/adjudication/round1_excerpts.csv  \
  finish-line/adjudication/round1_excerpts_matched.csv finish-line/adjudication/round2_excerpts_merged.csv  \
  finish-line/adjudication/round2_excerpts.csv finish-line/adjudication/round2_excerpts_matched.csv \
  -o merge-all.csv
Loaded 4,264 excerpts from 5 files (1,090 labeled).
2,565 excerpts after merging; 876 labeled excerpts.
Total by detection method:
        adjudication: 2,565
Total by identification method:
        manual; refmatcha: 40
        manual: 173
        refmatcha: 663
```


I added the merge script to sphinx docs so that I could make sure the docstring was formatted correctly (it wasn't). I think we may want to make a separate section for the poetry detection code, but putting it at the top level for now.

question:
- do you think it is important now to setup parametrized unit tests so we can easily add test cases with expected number of resulting rows after merging? some of the existing tests could shift to this structure
