### PR TITLE
Basic setup for local configuration

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
             pip-
 
       - name: Install dependencies
-        run: pip install ".[test]"
+        run: pip install -e ".[test]"
 
       - name: Run pytest
         run: pytest --cov=corppa --cov=test --cov-report=xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # project specific
 # - don't check reference poetry data for identify_poems into version control
 poetry-reference-data/
+corppa.cfg
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ pip install -e ".[dev]"
 pre-commit install
 ```
 
+- Copy `sample.cfg` to `corppa.cfg` and edit paths and configurations for your local environment.
+
 ## Experimental Scripts
 
 Experimental scripts associated with `corppa` are located within the `scripts` directory.

--- a/sample.cfg
+++ b/sample.cfg
@@ -1,0 +1,6 @@
+# corppa configuration
+# copy this file to corppa.cfg and edit as needed
+
+# local path to compiled poem dataset files
+[poem_dataset]
+data_dir=/path/to/ppa-found-poems/data/

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -5,23 +5,22 @@ Load local configuration options
 import configparser
 import pathlib
 
-#: src dir relative to this file (assumeing dev environment for now)
-CORPPA_SRC_DIR = pathlib.Path(__file__).parent.absolute()
+#: src dir relative to this file (assuming dev environment for now)
+CORPPA_SRC_DIR = pathlib.Path(__file__).parent.parent.absolute()
 
-#: expected patch for local config file (non-versioned)
+#: expected path for local config file (non-versioned)
 CORPPA_CONFIG_PATH = CORPPA_SRC_DIR.parent / "corppa.cfg"
-#: expected patch for example config file
+#: expected path for example config file
 SAMPLE_CONFIG_PATH = CORPPA_SRC_DIR.parent / "sample.cfg"
-
-CFG_NOT_FOUND_MESSAGE = f""""Config file not found.
-Copy {SAMPLE_CONFIG_PATH} to {CORPPA_CONFIG_PATH} and configure for your environment.
-"""
 
 
 def get_config():
     # if the config file is not in place
     if not CORPPA_CONFIG_PATH.exists():
-        raise SystemExit(CFG_NOT_FOUND_MESSAGE)
+        not_found_msg = f""""Config file not found.
+Copy {SAMPLE_CONFIG_PATH} to {CORPPA_CONFIG_PATH} and configure for your environment.
+"""
+        raise SystemExit(not_found_msg)
 
     config = configparser.ConfigParser()
     config.read(CORPPA_CONFIG_PATH)

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -1,0 +1,28 @@
+"""
+Load local configuration options
+"""
+
+import configparser
+import pathlib
+
+#: src dir relative to this file (assumeing dev environment for now)
+CORPPA_SRC_DIR = pathlib.Path(__file__).parent.absolute()
+
+#: expected patch for local config file (non-versioned)
+CORPPA_CONFIG_PATH = CORPPA_SRC_DIR.parent / "corppa.cfg"
+#: expected patch for example config file
+SAMPLE_CONFIG_PATH = CORPPA_SRC_DIR.parent / "sample.cfg"
+
+CFG_NOT_FOUND_MESSAGE = f""""Config file not found.
+Copy {SAMPLE_CONFIG_PATH} to {CORPPA_CONFIG_PATH} and configure for your environment.
+"""
+
+
+def get_config():
+    # if the config file is not in place
+    if not CORPPA_CONFIG_PATH.exists():
+        raise SystemExit(CFG_NOT_FOUND_MESSAGE)
+
+    config = configparser.ConfigParser()
+    config.read(CORPPA_CONFIG_PATH)
+    return config

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -17,9 +17,10 @@ SAMPLE_CONFIG_PATH = CORPPA_SRC_DIR.parent / "sample.cfg"
 def get_config():
     # if the config file is not in place
     if not CORPPA_CONFIG_PATH.exists():
-        not_found_msg = f""""Config file not found.
-Copy {SAMPLE_CONFIG_PATH} to {CORPPA_CONFIG_PATH} and configure for your environment.
-"""
+        not_found_msg = (
+            "Config file not found.\n"
+            + f"Copy {SAMPLE_CONFIG_PATH} to {CORPPA_CONFIG_PATH} and configure for your environment."
+        )
         raise SystemExit(not_found_msg)
 
     config = configparser.ConfigParser()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,11 +6,13 @@ from corppa import config
 
 
 def test_get_config_not_found(tmp_path):
-    with pytest.raises(SystemExit, match="Config file not found") as err:
-        config.get_config()
+    test_config = tmp_path / "test.cfg"
     # error should include directions about how to fix the problem
-    help_msg = f"Copy {config.SAMPLE_CONFIG_PATH} to {config.CORPPA_CONFIG_PATH} and configure for your environment."
-    assert help_msg in str(err)
+    expected_error_msg = f"""Config file not found.
+Copy .*{config.SAMPLE_CONFIG_PATH.name} to .*{test_config.name} and configure for your environment."""
+    with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
+        with pytest.raises(SystemExit, match=expected_error_msg):
+            config.get_config()
 
 
 def test_get_config(tmp_path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+import pytest
+
+from corppa import config
+
+
+def test_get_config_not_found(tmp_path):
+    with pytest.raises(SystemExit, match="Config file not found") as err:
+        config.get_config()
+    # error should include directions about how to fix the problem
+    help_msg = f"Copy {config.SAMPLE_CONFIG_PATH} to {config.CORPPA_CONFIG_PATH} and configure for your environment."
+    assert help_msg in str(err)
+
+
+def test_get_config(tmp_path):
+    # create a test config file with one section and one value
+    test_config = tmp_path / "test.cfg"
+    test_config.write_text("""
+# local path to compiled poem dataset files        
+[poem_dataset]
+data_dir=/tmp/p-p-poems/data
+""")
+    # use patch to override the config path and load our test file
+    with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
+        config_opts = config.get_config()
+        assert "poem_dataset" in config_opts.sections()
+        assert config_opts["poem_dataset"]["data_dir"] == "/tmp/p-p-poems/data"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,8 +8,10 @@ from corppa import config
 def test_get_config_not_found(tmp_path):
     test_config = tmp_path / "test.cfg"
     # error should include directions about how to fix the problem
-    expected_error_msg = f"""Config file not found.
-Copy .*{config.SAMPLE_CONFIG_PATH.name} to .*{test_config.name} and configure for your environment."""
+    expected_error_msg = (
+        "Config file not found.\n"
+        + f"Copy .*{config.SAMPLE_CONFIG_PATH.name} to .*{test_config.name} and configure for your environment."
+    )
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         with pytest.raises(SystemExit, match=expected_error_msg):
             config.get_config()


### PR DESCRIPTION
configuration setup for the notebook (and elsewhere) - related to #152 

Now updated with corrected paths and test paths now that I've tested it with the notebook.

In this pr:

- new `corppa.config` file with utility method `get_config`
- unit tests for loading config options and error handling  when config file is not present
- sample config file with one section and one path for now
- gitignore to keep the local config from being checked in
- added a note about config file to developer setup instructions 


I went with the python built in `configparser` since the toml support is read-only and we might eventually want more than that.

Note: I switched unit tests to use an editable pip install (`-e`) so that the configpath error test case matches local development; otherwise the path is relative to a package install instead of current working directory.